### PR TITLE
Fix crash loop after first Lightning/Spark payment

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/MultiDeviceOutgoingPaymentSyncJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/MultiDeviceOutgoingPaymentSyncJob.java
@@ -17,6 +17,7 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientUtil;
 import org.whispersystems.signalservice.api.messages.multidevice.OutgoingPaymentMessage;
 import org.whispersystems.signalservice.api.messages.multidevice.SignalServiceSyncMessage;
+import org.whispersystems.signalservice.api.payments.Money;
 import org.signal.core.models.ServiceId;
 import org.whispersystems.signalservice.api.push.exceptions.PushNetworkException;
 import org.whispersystems.signalservice.api.push.exceptions.ServerRejectedException;
@@ -83,6 +84,11 @@ public final class MultiDeviceOutgoingPaymentSyncJob extends BaseJob {
 
     if (payment == null) {
       Log.w(TAG, "Payment not found " + uuid);
+      return;
+    }
+
+    if (!(payment.getAmount() instanceof Money.MobileCoin)) {
+      Log.i(TAG, "Skipping multi-device sync for non-MobileCoin payment " + this.uuid);
       return;
     }
 


### PR DESCRIPTION
## Summary

- **Fix infinite crash loop** triggered after the first successful Lightning/Spark payment
- `MultiDeviceOutgoingPaymentSyncJob` unconditionally calls `.requireMobileCoin()` on payment amounts, but Lightning payments store amounts as `Money.Satoshi` — this throws `AssertionError`, killing the process
- The failed job persists in the job queue, so on restart it immediately re-runs and crashes again (observed as 7+ consecutive crashes in logcat within ~3 minutes)
- Lightning/Spark payments don't need MobileCoin's TXO-based multi-device sync — linked devices share the same Breez SDK wallet seed and discover payments via their own SDK connection

## Root Cause

```
FATAL EXCEPTION: JobRunner-Core-1
Process: com.radarlabs.radar
java.lang.AssertionError
    at org.whispersystems.signalservice.api.payments.Money.requireMobileCoin(Money.java:105)
    at org.thoughtcrime.securesms.jobs.MultiDeviceOutgoingPaymentSyncJob.onRun(MultiDeviceOutgoingPaymentSyncJob.java:107)
```

The payment send chain is: `PaymentSendJob` → `PaymentTransactionCheckJob` → `MultiDeviceOutgoingPaymentSyncJob`. The first two jobs succeed, but the sync job was never updated for the MobileCoin → Lightning migration.

## Fix

Early-return in `MultiDeviceOutgoingPaymentSyncJob.onRun()` when the payment amount is not `Money.MobileCoin`. This is semantically correct: Spark/Lightning wallets are seed-shared across devices, so there is no TXO receipt to sync via Signal's multi-device protocol.

## Test plan

- [x] Verified crash reproduces on device (logcat confirms `AssertionError` at line 107)
- [x] Applied fix, built `playProdDebug`, installed via `adb install`
- [ ] **Unable to fully test payment flow** — the debug-signed APK cannot register with Signal servers (signature mismatch with the release build's push registration), so sending a payment end-to-end requires a release-signed build
- [ ] Verify payment appears in transaction history on both primary and linked device (via shared Breez SDK seed)
- [ ] Verify MobileCoin payments (if ever re-enabled) would still sync correctly (instanceof check passes for MobileCoin amounts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)