### PR TITLE
Fix payment fee deducted from recipient instead of added to sender

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/Wallet.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/Wallet.java
@@ -202,7 +202,8 @@ public final class Wallet {
     Log.i(TAG, "Sending payment to " + to + " with amount " + amount + " and fee " + totalFee);
 
     try {
-      BreezSdkWrapper.SendPaymentResult result = breezSdkWrapper.sendPayment(to.getPaymentAddress(), amount.requireBitcoin().toSatoshiBigInteger());
+      BigInteger amountWithFee = amount.requireBitcoin().toSatoshiBigInteger().add(totalFee.requireBitcoin().toSatoshiBigInteger());
+      BreezSdkWrapper.SendPaymentResult result = breezSdkWrapper.sendPayment(to.getPaymentAddress(), amountWithFee);
 
       // Persist the actual fee charged by the network (from the prepared payment) so the
       // payment details screen shows the real fee, matching iOS. Falls back to the advised


### PR DESCRIPTION
## Summary

Fixes a bug where the recipient receives less than the user intended because the routing fee is subtracted from the send amount rather than added on top.

**Example:** User selects 21 sats, confirm screen shows "+2 sat fee = 23 total", but recipient only gets 19 sats (21 - 2).

## Root Cause

`Wallet.sendPayment()` passes only the base `amount` (21 sats) to `BreezSdkWrapper.sendPayment()`. The Breez SDK interprets this as the **total envelope** — it routes 21 sats and deducts the 2 sat routing fee internally, delivering only 19 to the recipient.

The confirm screen presents the fee as additive (`amount + fee = total debit`), creating a mismatch between what the user approved and what actually happens.

## Observed on device

After sending a payment with 21 sats selected (2 sat fee shown on confirm screen), the transaction history displayed 19 sats sent — confirming the fee was subtracted from the send amount rather than added on top. The related crash loop from PR #7 also triggered immediately after, showing the payment was persisted with Satoshi-denominated amounts:

```
07-07 15:47:13.819 E/AndroidRuntime(15225): FATAL EXCEPTION: JobRunner-Temp-9
07-07 15:47:13.819 E/AndroidRuntime(15225): Process: com.radarlabs.radar, PID: 15225
07-07 15:47:13.819 E/AndroidRuntime(15225): java.lang.AssertionError
07-07 15:47:13.819 E/AndroidRuntime(15225): 	at org.whispersystems.signalservice.api.payments.Money.requireMobileCoin(Money.java:105)
07-07 15:47:13.819 E/AndroidRuntime(15225): 	at org.thoughtcrime.securesms.jobs.MultiDeviceOutgoingPaymentSyncJob.onRun(MultiDeviceOutgoingPaymentSyncJob.java:107)
```

(The crash confirms the payment *did* go through — `PaymentSendJob` succeeded and persisted the result before `MultiDeviceOutgoingPaymentSyncJob` crashed trying to sync it.)

## Code path trace

```
ConfirmPaymentRepository.confirmPayment()
  → PaymentSendJob.enqueuePayment(address, amount=21, fee=2)
    → Wallet.sendPayment(address, amount=21, totalFee=2)
      → breezSdkWrapper.sendPayment(address, 21)  // ← only base amount passed
        → prepareLnurl(address, 21)                // SDK treats 21 as total envelope
        → sdk.lnurlPay(...)                        // routes 21, deducts 2 fee → recipient gets 19
```

## Fix

Pass `amount + fee` to the Breez SDK so the total envelope covers both the intended recipient amount and the routing fee:

```java
// Before: recipient gets (amount - fee) = 19
breezSdkWrapper.sendPayment(to.getPaymentAddress(), amount.requireBitcoin().toSatoshiBigInteger());

// After: recipient gets amount = 21, sender pays (amount + fee) = 23
BigInteger amountWithFee = amount.requireBitcoin().toSatoshiBigInteger()
    .add(totalFee.requireBitcoin().toSatoshiBigInteger());
breezSdkWrapper.sendPayment(to.getPaymentAddress(), amountWithFee);
```

## Test plan

- [ ] Send a payment and verify the recipient receives the exact amount shown on the confirm screen
- [ ] Verify transaction history shows the correct sent amount (not reduced by fee)
- [ ] Verify the fee displayed in payment details matches the fee shown at confirmation
- **Note:** Unable to fully verify on device — debug-signed APK cannot register with Signal servers

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)