### PR TITLE
Show sender message on received Lightning payments

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/MobileCoinLedgerWrapper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/MobileCoinLedgerWrapper.kt
@@ -53,6 +53,10 @@ class MobileCoinLedgerWrapper(private val lnWrapper: BreezSdkWrapper) {
         return ByteString.EMPTY
       }
 
+    /** LNURL sender comment on a received lightning payment, or null. */
+    val senderComment: String?
+      get() = (payment.details as? PaymentDetails.Lightning)?.lnurlReceiveMetadata?.senderComment
+
     val receivedInBlock: Long
       get() = 0
 

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/Payment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/Payment.java
@@ -49,6 +49,14 @@ public interface Payment {
   @NonNull String getNote();
 
   /**
+   * The LNURL sender comment attached to a received lightning payment, or null if none.
+   * Defaults to null so only payment types that actually carry one need to override it.
+   */
+  default @Nullable String getSenderComment() {
+    return null;
+  }
+
+  /**
    * Always >= 0, does not include fee
    */
   @NonNull Money getAmount();

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/PaymentParcelable.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/PaymentParcelable.java
@@ -65,6 +65,7 @@ public class PaymentParcelable implements Parcelable {
     }
 
     dest.writeString(payment.getNote());
+    dest.writeString(payment.getSenderComment());
     dest.writeString(payment.getAmount().serialize());
     dest.writeString(payment.getFee().serialize());
     dest.writeByteArray(payment.getPaymentMetaData().encode());
@@ -86,6 +87,7 @@ public class PaymentParcelable implements Parcelable {
     private final State           state;
     private final FailureReason   failureReason;
     private final String          note;
+    private final String          senderComment;
     private final Money           amount;
     private final Money           fee;
     private final PaymentMetaData paymentMetaData;
@@ -116,6 +118,7 @@ public class PaymentParcelable implements Parcelable {
         }
 
         note                       = in.readString();
+        senderComment              = in.readString();
         amount                     = Money.parse(in.readString());
         fee                        = Money.parse(in.readString());
         paymentMetaData            = PaymentMetaData.ADAPTER.decode(in.createByteArray());
@@ -176,6 +179,11 @@ public class PaymentParcelable implements Parcelable {
     @Override
     public @NonNull String getNote() {
       return note;
+    }
+
+    @Override
+    public @Nullable String getSenderComment() {
+      return senderComment;
     }
 
     @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/ReconstructedPayment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/ReconstructedPayment.kt
@@ -10,7 +10,8 @@ class ReconstructedPayment(
   private val blockTimestamp: Long,
   private val direction: Direction,
   private val amount: Money,
-  private val fee: Money
+  private val fee: Money,
+  private val senderComment: String? = null
 ) : Payment {
   override fun getUuid(): UUID = UuidUtil.UNKNOWN_UUID
 
@@ -29,6 +30,8 @@ class ReconstructedPayment(
   override fun getFailureReason(): FailureReason? = null
 
   override fun getNote(): String = ""
+
+  override fun getSenderComment(): String? = senderComment
 
   override fun getAmount(): Money = amount
 

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/details/PaymentDetailsFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/details/PaymentDetailsFragment.java
@@ -7,6 +7,7 @@ import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
+import android.text.util.Linkify;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
@@ -17,9 +18,13 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.constraintlayout.widget.Group;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.method.LinkMovementMethodCompat;
+import androidx.core.text.util.LinkifyCompat;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.Navigation;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.signal.core.util.concurrent.SimpleTask;
 import org.signal.core.util.logging.Log;
@@ -69,6 +74,7 @@ public final class PaymentDetailsFragment extends LoggingFragment {
     TextView          contactFromTo   = view.findViewById(R.id.payments_details_contact_to_from);
     MoneyView         amount          = view.findViewById(R.id.payments_details_amount);
     TextView          note            = view.findViewById(R.id.payments_details_note);
+    TextView          message         = view.findViewById(R.id.payments_details_message);
     TextView          status          = view.findViewById(R.id.payments_details_status);
     View              sentByHeader    = view.findViewById(R.id.payments_details_sent_by_header);
     TextView          sentBy          = view.findViewById(R.id.payments_details_sent_by);
@@ -86,6 +92,7 @@ public final class PaymentDetailsFragment extends LoggingFragment {
       contactFromTo.setText(getContactFromToTextFromDirection(payment.getDirection()));
       amount.setMoney(payment.getAmountPlusFeeWithDirection());
       note.setVisibility(View.GONE);
+      bindSenderComment(message, payment.getSenderComment());
       status.setText(getStatusFromPayment(payment));
       sentByHeader.setVisibility(View.GONE);
       sentBy.setVisibility(View.GONE);
@@ -143,6 +150,7 @@ public final class PaymentDetailsFragment extends LoggingFragment {
                           String trimmedNote = state.getPayment().getNote().trim();
                           note.setText(trimmedNote);
                           note.setVisibility(TextUtils.isEmpty(trimmedNote) ? View.GONE : View.VISIBLE);
+                          bindSenderComment(message, state.getPayment().getSenderComment());
                           status.setText(describeStatus(state.getPayment()));
                           sentBy.setText(describeSentBy(state));
                           if (state.getPayment().getDirection().isReceived()) {
@@ -168,6 +176,35 @@ public final class PaymentDetailsFragment extends LoggingFragment {
                  }
                });
     }
+  }
+
+  private void bindSenderComment(@NonNull TextView view, @Nullable String comment) {
+    String trimmed = comment == null ? "" : comment.trim();
+    if (TextUtils.isEmpty(trimmed)) {
+      view.setVisibility(View.GONE);
+      return;
+    }
+    view.setVisibility(View.VISIBLE);
+    view.setText(trimmed);
+    view.setOnClickListener(v -> showSenderCommentDialog(trimmed));
+  }
+
+  private void showSenderCommentDialog(@NonNull String comment) {
+    SpannableString spannable = new SpannableString(comment);
+    LinkifyCompat.addLinks(spannable, Linkify.WEB_URLS | Linkify.EMAIL_ADDRESSES);
+
+    int      padding  = (int) (24 * getResources().getDisplayMetrics().density);
+    TextView textView = new TextView(requireContext());
+    textView.setPadding(padding, padding, padding, padding);
+    textView.setText(spannable);
+    textView.setTextColor(ContextCompat.getColor(requireContext(), R.color.signal_text_primary));
+    textView.setMovementMethod(LinkMovementMethodCompat.getInstance());
+
+    new MaterialAlertDialogBuilder(requireContext())
+        .setTitle(R.string.PaymentsDetailsFragment__message_from_sender)
+        .setView(textView)
+        .setPositiveButton(android.R.string.ok, null)
+        .show();
   }
 
   private void openConversation(@NonNull RecipientId recipientId) {

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/reconciliation/LedgerReconcile.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/reconciliation/LedgerReconcile.java
@@ -67,7 +67,7 @@ public final class LedgerReconcile {
     localPayments.addAll(allLocalPaymentTransactions);
 
     for (MobileCoinLedgerWrapper.OwnedTxo txo : unknownTxOutsReceived) {
-      reconstructedPayments.add(new ReconstructedPayment(0L, txo.getReceivedInBlockTimestamp(), txo.getDirection(), txo.getValue(), txo.getFee()));
+      reconstructedPayments.add(new ReconstructedPayment(0L, txo.getReceivedInBlockTimestamp(), txo.getDirection(), txo.getValue(), txo.getFee(), txo.getSenderComment()));
     }
 
     reconstructedPayments.sort(Payment.DESCENDING_TIMESTAMP);

--- a/app/src/main/res/layout/payment_details_fragment.xml
+++ b/app/src/main/res/layout/payment_details_fragment.xml
@@ -108,13 +108,33 @@
                 app:layout_constraintTop_toBottomOf="@id/payments_details_amount"
                 tools:text="Thanks for dinner!" />
 
+            <TextView
+                android:id="@+id/payments_details_message"
+                style="@style/Signal.Text.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="16dp"
+                android:ellipsize="end"
+                android:maxLines="3"
+                android:textColor="@color/signal_text_secondary"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/payments_details_note"
+                app:layout_goneMarginTop="12dp"
+                tools:text="Check out https://example.com — thanks for the Satogram!"
+                tools:visibility="visible" />
+
             <View
                 android:id="@+id/payments_details_horizontal_divide"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_marginTop="32dp"
                 android:background="@color/signal_background_secondary"
-                app:layout_constraintTop_toBottomOf="@id/payments_details_note" />
+                app:layout_goneMarginTop="32dp"
+                app:layout_constraintTop_toBottomOf="@id/payments_details_message" />
 
             <TextView
                 android:id="@+id/payments_details_sent_to_header"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4479,6 +4479,7 @@
     <string name="PaymentsDetailsFragment__coin_cleanup_fee">Coin cleanup fee</string>
     <string name="PaymentsDetailsFragment__coin_cleanup_information">A “coin cleanup fee” is charged when the coins in your possession can not be combined to complete a transaction. Cleanup will allow you to continue sending payments.</string>
     <string name="PaymentsDetailsFragment__no_details_available">No further details available for this transaction</string>
+    <string name="PaymentsDetailsFragment__message_from_sender">Message</string>
     <string name="PaymentsDetailsFragment__learn_more__information" translatable="false">https://support.signal.org/hc/articles/360057625692#payments_details</string>
     <string name="PaymentsDetailsFragment__learn_more__cleanup_fee" translatable="false">https://support.signal.org/hc/articles/360057625692#payments_details_fees</string>
     <string name="PaymentsDetailsFragment__sent_payment">Sent payment</string>


### PR DESCRIPTION
### Contributor checklist

- [x] I am following the Code Style Guidelines
- [ ] I have tested my contribution on these devices:
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message

----------

### Description

Received Lightning payments to a Radar (`@radar.cash`) address can carry a free-form
sender comment (the payer's LNURL / LUD-12 comment). The Breez Spark SDK exposes it on
the payment via `PaymentDetails.Lightning.lnurlReceiveMetadata.senderComment`, but it was
being dropped, so recipients never saw any message attached to a payment.

This surfaces that comment on the payment details screen for received lightning payments:

- `OwnedTxo.senderComment` extracts it from the Breez `Payment`.
- It flows through `ReconstructedPayment` → `PaymentParcelable` to the details screen (the
  path external lightning-address receives take), where a new **Message** row shows a
  truncated preview.
- Tapping the preview opens a dialog with the full message, where any URLs are tappable and
  open in the browser.
- The message content is displayed verbatim and is never altered or translated.

`Payment.getSenderComment()` is added as a `default` interface method returning null, so no
other `Payment` implementer needs to change.

**Note:** this was authored without an Android build available in my environment. Please run
a Gradle build and an on-device test before merging. The sender comment is untrusted remote
input; it is rendered as plain text with only well-formed URLs linkified.
