### PR TITLE
Fix Signal migration restore route

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/welcome/SignUpFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/welcome/SignUpFragment.kt
@@ -157,7 +157,7 @@ class SignUpFragment : LoggingFragment(R.layout.fragment_registration_sign_up) {
       }
       WelcomeUserSelection.MIGRATE_FROM_SIGNAL -> {
         sharedViewModel.intendToRestore(hasOldDevice = true, fromRemote = true)
-        findNavController().safeNavigate(SignUpFragmentDirections.goToMigrateFromSignal())
+        findNavController().safeNavigate(SignUpFragmentDirections.goToRestoreViaQr())
       }
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/welcome/WelcomeFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/welcome/WelcomeFragment.kt
@@ -147,7 +147,7 @@ class WelcomeFragment : LoggingFragment(R.layout.fragment_registration_welcome_v
       }
       WelcomeUserSelection.MIGRATE_FROM_SIGNAL -> {
         sharedViewModel.intendToRestore(hasOldDevice = true, fromRemote = true)
-        findNavController().safeNavigate(WelcomeFragmentDirections.goToMigrateFromSignal())
+        findNavController().safeNavigate(WelcomeFragmentDirections.goToRestoreViaQr())
       }
     }
   }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8819,10 +8819,10 @@
     <!-- Row subtitle for restore/transfer without using a previous device -->
     <string name="WelcomeFragment_restore_action_reinstalling">Or you\'re reinstalling Radar on the same device</string>
 
-    <!-- Row title for migrating an account from the Signal app installed on this device -->
+    <!-- Row title for migrating an account from Signal on a previous device -->
     <string name="WelcomeFragment_restore_action_migrate_from_signal">Migrate from Signal</string>
-    <!-- Row subtitle for migrating an account from the Signal app installed on this device -->
-    <string name="WelcomeFragment_restore_action_migrate_from_signal_subtitle">Restore your account from the Signal app installed on this device</string>
+    <!-- Row subtitle for migrating an account from Signal on a previous device -->
+    <string name="WelcomeFragment_restore_action_migrate_from_signal_subtitle">Use Signal on your old phone to scan a QR code and transfer your account</string>
     <!-- Row title for restore/transfer by scanning a QR code with a previous device -->
     <string name="WelcomeFragment_restore_action_set_up_new_phone">Set up my new phone</string>
     <!-- Row subtitle for restore/transfer by scanning a QR code with a previous device -->


### PR DESCRIPTION
## Summary

- Route the "Migrate from Signal" onboarding choice to the existing QR restore flow instead of the same-device Signal handoff.
- Update the row copy so it describes scanning a QR code with the old Signal device.

## Why

The previous flow generated a Radar `sgnl://rereg` provisioning URL and opened it in the official Signal package. Signal then starts its transfer scanner and expects a QR code, while Radar waits on the provisioning socket, leaving users at the dead end reported in #16. The supported rereg flow is old-device scanning of the new-device QR.

A true same-device Signal-to-Radar migration would require official Signal-side support to export the rereg provisioning payload to Radar; Radar cannot force that via an intent alone.

Fixes #16

## Validation

- `./gradlew --console=plain --max-workers=2 :Signal-Android:compilePlayProdDebugKotlin`
- Result: `BUILD SUCCESSFUL in 12m 3s`
