### PR TITLE
Tell users to back up Signal before migrating

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/restore/MigrateFromSignalFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/restore/MigrateFromSignalFragment.kt
@@ -228,6 +228,38 @@ private fun MigrateFromSignalScreen(
           .size(64.dp)
       )
 
+      // Message history comes across from the user's Signal backup, not from the live handoff, so
+      // say so before they leave for Signal — afterwards is too late, and the only alternative is
+      // the "nothing to restore" dead end further down this flow. Mirrors the disclaimer iOS shows
+      // on its own migrate path (b4f557f2be), adapted to the fact that Android hands off live.
+      Column(
+        modifier = Modifier
+          .widthIn(max = 320.dp)
+          .padding(bottom = 24.dp)
+      ) {
+        Text(
+          text = stringResource(R.string.MigrateFromSignal_before_you_start),
+          style = MaterialTheme.typography.titleSmall,
+          color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+          text = stringResource(R.string.MigrateFromSignal_backup_step_1),
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+          text = stringResource(R.string.MigrateFromSignal_backup_step_2),
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+      }
+
       Column(modifier = Modifier.widthIn(max = 320.dp)) {
         MigrateInstructionRow(
           icon = painterResource(R.drawable.symbol_device_phone_24),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8844,6 +8844,12 @@
     <string name="MigrateFromSignal_instruction_3">Come back to Radar to finish setting up</string>
     <!-- Button label that opens the Signal app to start the migration -->
     <string name="MigrateFromSignal_open_signal">Open Signal</string>
+    <!-- Heading of the advisory shown before migrating, telling the user to back up Signal first -->
+    <string name="MigrateFromSignal_before_you_start">Before you start</string>
+    <!-- First thing to do in Signal before migrating -->
+    <string name="MigrateFromSignal_backup_step_1">In Signal, go to Settings → Backups and create a backup if you haven\'t already</string>
+    <!-- Second thing to do in Signal before migrating -->
+    <string name="MigrateFromSignal_backup_step_2">Securely save your Recovery Key so your messages can be restored</string>
     <!-- Error message shown when the Signal app is not installed on this device -->
     <string name="MigrateFromSignal_signal_not_installed">Couldn\'t find the Signal app on this device. Make sure it is installed and up to date, then try again.</string>
     <!-- Error message shown when the migration could not be prepared, e.g. no network connection -->


### PR DESCRIPTION
iOS added a screen on its migrate path telling the user to create a Signal backup and save their Recovery Key before logging in to Radar (b4f557f2be). Android's migrate screen explained the handoff — open Signal, confirm, come back — but said nothing about backups.

That matters here for the same reason it does on iOS, even though the mechanism differs. Android hands a provisioning URI to the installed Signal app, and the account comes across live; message history does not. It is restored from the user's Signal backup, which is why this flow already has a "nothing to restore" branch for a provisioning message that arrives without a backup tier. By the time a user lands there they have already migrated and it is too late to go back and make one.

So this is an advisory placed above the existing numbered steps rather than a separate screen: iOS's two points, worded for Android's flow, while the user can still leave and go make a backup. Deliberately not a blocking "I've completed a backup" confirmation like iOS's — Android's handoff is a live transfer that works without a backup, just with less history, and gating it would stop people who genuinely have nothing to restore.

Verified: :Signal-Android:compilePlayProdDebugKotlin.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
