### PR TITLE
Add the username step to payments onboarding

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/onboarding/PaymentsOnboardingUsernameFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/onboarding/PaymentsOnboardingUsernameFragment.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.payments.onboarding
+
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.navigation.fragment.NavHostFragment
+import com.google.android.material.button.MaterialButton
+import org.thoughtcrime.securesms.LoggingFragment
+import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.keyvalue.SignalStore
+
+/**
+ * First step of payments onboarding: settle the user's Signal/Radar username, which is how other
+ * people find them. Mirrors iOS UsernameOnboardingViewController, which its onboarding coordinator
+ * presents before the payments intro.
+ *
+ * The screen adapts to what is already set. With a username it reads as a confirmation and offers
+ * to edit; without one it invites the user to pick. Either way it is skippable — a username is not
+ * required to send or receive, so blocking onboarding on it would be wrong.
+ *
+ * Editing delegates to the existing [org.thoughtcrime.securesms.profiles.manage.UsernameEditFragment]
+ * rather than reimplementing availability checks and validation. That screen pops when it is done,
+ * which lands back here, so [onResume] re-reads the state.
+ */
+class PaymentsOnboardingUsernameFragment : LoggingFragment(R.layout.fragment_payments_onboarding_username) {
+
+  private lateinit var subtitle: TextView
+  private lateinit var usernameView: TextView
+  private lateinit var primary: MaterialButton
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    subtitle = view.findViewById(R.id.onboarding_username_subtitle)
+    usernameView = view.findViewById(R.id.onboarding_username_value)
+    primary = view.findViewById(R.id.onboarding_username_primary)
+
+    view.findViewById<MaterialButton>(R.id.onboarding_username_skip).setOnClickListener { continueToIntro() }
+  }
+
+  override fun onResume() {
+    super.onResume()
+    render()
+  }
+
+  private fun render() {
+    val username = SignalStore.account.username
+
+    if (username.isNullOrBlank()) {
+      subtitle.setText(R.string.PaymentsOnboarding__username_subtitle)
+      usernameView.visibility = View.GONE
+      primary.setText(R.string.PaymentsOnboarding__username_set)
+      primary.setOnClickListener { editUsername() }
+    } else {
+      subtitle.setText(R.string.PaymentsOnboarding__username_existing_subtitle)
+      usernameView.visibility = View.VISIBLE
+      usernameView.text = username
+      primary.setText(R.string.PaymentsOnboarding__username_confirm)
+      primary.setOnClickListener { continueToIntro() }
+    }
+  }
+
+  private fun editUsername() {
+    NavHostFragment.findNavController(this).navigate(R.id.action_username_to_editUsername)
+  }
+
+  private fun continueToIntro() {
+    NavHostFragment.findNavController(this).navigate(R.id.action_username_to_intro)
+  }
+}

--- a/app/src/main/res/layout/fragment_payments_onboarding_username.xml
+++ b/app/src/main/res/layout/fragment_payments_onboarding_username.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/signal_background_primary"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:paddingStart="32dp"
+            android:paddingEnd="32dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="64dp"
+                android:gravity="center"
+                android:text="@string/PaymentsOnboarding__username_title"
+                android:textAppearance="@style/Signal.Text.TitleLarge"
+                android:textColor="@color/signal_text_primary" />
+
+            <TextView
+                android:id="@+id/onboarding_username_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.Signal.Body2"
+                android:textColor="@color/signal_text_secondary"
+                tools:text="@string/PaymentsOnboarding__username_subtitle" />
+
+            <TextView
+                android:id="@+id/onboarding_username_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:gravity="center"
+                android:textAppearance="@style/Signal.Text.TitleLarge"
+                android:textColor="@color/radar_accent_blue"
+                android:visibility="gone"
+                tools:text="alice.42"
+                tools:visibility="visible" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/onboarding_username_primary"
+        style="@style/Signal.Widget.Button.Large.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:layout_marginStart="40dp"
+        android:layout_marginEnd="40dp"
+        android:textAllCaps="false"
+        app:cornerRadius="14dp"
+        tools:text="@string/PaymentsOnboarding__username_confirm" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/onboarding_username_skip"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="40dp"
+        android:layout_marginEnd="40dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/PaymentsOnboarding__skip_this_step"
+        android:textAllCaps="false" />
+
+</LinearLayout>

--- a/app/src/main/res/navigation/payments_onboarding.xml
+++ b/app/src/main/res/navigation/payments_onboarding.xml
@@ -3,7 +3,28 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/payments_onboarding"
-    app:startDestination="@id/paymentsOnboardingIntro">
+    app:startDestination="@id/paymentsOnboardingUsername">
+
+    <!--
+      Username step, ahead of the payments intro, mirroring iOS's onboarding coordinator. Editing
+      delegates to the shared UsernameEditFragment, which pops back here when it is done.
+    -->
+    <fragment
+        android:id="@+id/paymentsOnboardingUsername"
+        android:name="org.thoughtcrime.securesms.payments.onboarding.PaymentsOnboardingUsernameFragment"
+        tools:layout="@layout/fragment_payments_onboarding_username">
+        <action
+            android:id="@+id/action_username_to_intro"
+            app:destination="@id/paymentsOnboardingIntro" />
+        <action
+            android:id="@+id/action_username_to_editUsername"
+            app:destination="@id/paymentsOnboardingEditUsername" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/paymentsOnboardingEditUsername"
+        android:name="org.thoughtcrime.securesms.profiles.manage.UsernameEditFragment"
+        tools:layout="@layout/username_edit_fragment" />
 
     <fragment
         android:id="@+id/paymentsOnboardingIntro"
@@ -24,7 +45,7 @@
         <action
             android:id="@+id/action_addFundsIntro_to_setupComplete"
             app:destination="@id/paymentsOnboardingSetupComplete"
-            app:popUpTo="@id/paymentsOnboardingIntro"
+            app:popUpTo="@id/paymentsOnboardingUsername"
             app:popUpToInclusive="true" />
     </fragment>
 
@@ -39,7 +60,7 @@
         <action
             android:id="@+id/action_addFunds_to_setupComplete"
             app:destination="@id/paymentsOnboardingSetupComplete"
-            app:popUpTo="@id/paymentsOnboardingIntro"
+            app:popUpTo="@id/paymentsOnboardingUsername"
             app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_addFunds_to_depositReceived"
@@ -59,7 +80,7 @@
         <action
             android:id="@+id/action_depositReceived_to_setupComplete"
             app:destination="@id/paymentsOnboardingSetupComplete"
-            app:popUpTo="@id/paymentsOnboardingIntro"
+            app:popUpTo="@id/paymentsOnboardingUsername"
             app:popUpToInclusive="true" />
     </fragment>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4421,6 +4421,16 @@
     <string name="PaymentsOnboarding__skip">Skip</string>
     <!-- Skip button on the Add Funds onboarding step -->
     <string name="PaymentsOnboarding__skip_this_step">Skip this step</string>
+    <!-- Title of the username step of payments onboarding -->
+    <string name="PaymentsOnboarding__username_title">Your Username</string>
+    <!-- Subtitle shown on the username onboarding step when no username is set yet -->
+    <string name="PaymentsOnboarding__username_subtitle">Set your custom username for connecting with other users on Radar and Signal</string>
+    <!-- Subtitle shown on the username onboarding step when a username is already set -->
+    <string name="PaymentsOnboarding__username_existing_subtitle">This is your username for connecting with other users on Radar and Signal</string>
+    <!-- Button that opens the username editor from payments onboarding -->
+    <string name="PaymentsOnboarding__username_set">Set my Username</string>
+    <!-- Button that accepts the existing username and continues payments onboarding -->
+    <string name="PaymentsOnboarding__username_confirm">Confirm</string>
     <!-- Deposit received screen title -->
     <string name="PaymentsOnboarding__deposit_received_title">Deposit Received</string>
     <!-- Deposit received screen subtitle -->


### PR DESCRIPTION
iOS's payments onboarding opens on a username screen — its coordinator presents UsernameOnboardingViewController before the payments intro — so a new wallet leaves setup findable by name. Android's flow started at the intro and never asked, which is also why nothing in the flow mentioned a username despite the send screen being able to search by one.

The new screen adapts to what is already set: with a username it reads as a confirmation and offers to edit, without one it invites the user to pick. It is skippable either way, because a username is not required to send or receive and blocking onboarding on it would be wrong.

Editing delegates to the existing UsernameEditFragment rather than reimplementing nickname validation, discriminator handling and the availability check. That fragment pops when it finishes, which lands back on this screen, so the state is re-read in onResume.

One thing that needed adjusting rather than just inserting a screen: three actions in this graph clear the flow with popUpTo/popUpToInclusive aimed at what used to be the start destination. Left alone, the username screen would have survived that pop and Back from "Setup complete" would have landed on it. They now target the new start destination.

Verified: :Signal-Android:compilePlayProdDebugKotlin.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
