### PR TITLE
Show recent payment recipients on the send screen

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ContactFilterView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ContactFilterView.java
@@ -197,6 +197,11 @@ public final class ContactFilterView extends FrameLayout {
     searchText.setSelection(searchText.getText().length());
   }
 
+  /** The current search text. */
+  public @NonNull String getQuery() {
+    return searchText.getText().toString();
+  }
+
   public void setOnFilterChangedListener(OnFilterChangedListener listener) {
     this.listener = listener;
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/PaymentRecipientSelectionFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/PaymentRecipientSelectionFragment.java
@@ -1,5 +1,18 @@
 package org.thoughtcrime.securesms.payments.preferences;
 
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
+import androidx.annotation.WorkerThread;
+import org.thoughtcrime.securesms.database.PaymentTable;
+import org.thoughtcrime.securesms.payments.Direction;
+import org.thoughtcrime.securesms.payments.Payee;
+import org.thoughtcrime.securesms.payments.Payment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
@@ -49,9 +62,13 @@ public class PaymentRecipientSelectionFragment extends LoggingFragment implement
   private static final String TAG = Log.tag(PaymentRecipientSelectionFragment.class);
 
   /** Loose "looks like a lightning address" gate (e.g. {@code name@radar.cash}) before we attempt to parse it. */
+  private static final int MAX_RECENT_RECIPIENTS = 5;
+
   private static final Pattern LIGHTNING_ADDRESS_SHAPE = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
 
   private Toolbar                      toolbar;
+  private TextView                     recentHeader;
+  private LinearLayout                 recentContainer;
   private ContactFilterView            contactFilterView;
   private TextView                     sendToAddressRow;
   private ContactSelectionListFragment contactsFragment;
@@ -81,6 +98,10 @@ public class PaymentRecipientSelectionFragment extends LoggingFragment implement
     toolbar = view.findViewById(R.id.payment_recipient_selection_fragment_toolbar);
     toolbar.setNavigationOnClickListener(v -> Navigation.findNavController(v).popBackStack());
 
+    recentHeader    = view.findViewById(R.id.payment_recipient_selection_fragment_recent_header);
+    recentContainer = view.findViewById(R.id.payment_recipient_selection_fragment_recents);
+    loadRecentRecipients();
+
     contactFilterView = view.findViewById(R.id.contact_filter_edit_text);
     contactFilterView.enablePaste();
     sendToAddressRow  = view.findViewById(R.id.payment_recipient_selection_fragment_send_to_address);
@@ -109,6 +130,7 @@ public class PaymentRecipientSelectionFragment extends LoggingFragment implement
     contactFilterView.setOnFilterChangedListener(filter -> {
       contactsFragment.setQueryFilter(filter);
       updateSendToAddressRow(filter);
+      setRecentsVisible(TextUtils.isEmpty(filter) && recentContainer.getChildCount() > 0);
     });
   }
 
@@ -238,6 +260,84 @@ public class PaymentRecipientSelectionFragment extends LoggingFragment implement
     CAN_SEND,
     NO_PROFILE_KEY,
     NOT_ENABLED
+  }
+
+  /**
+   * Fills the "Recent" section with the last few destinations this wallet paid, newest first.
+   * Mirrors the recent-recipients section on iOS's send screen, which is backed by the same
+   * outgoing-payment history.
+   */
+  private void loadRecentRecipients() {
+    SimpleTask.run(getViewLifecycleOwner().getLifecycle(),
+                   PaymentRecipientSelectionFragment::queryRecentPayees,
+                   this::bindRecentRecipients);
+  }
+
+  @WorkerThread
+  private static @NonNull List<Payee> queryRecentPayees() {
+    List<Payee>  payees = new ArrayList<>();
+    Set<String>  seen   = new HashSet<>();
+
+    List<PaymentTable.PaymentTransaction> all = new ArrayList<>(SignalDatabase.payments().getAll());
+    Collections.sort(all, Payment.DESCENDING_TIMESTAMP);
+
+    for (PaymentTable.PaymentTransaction transaction : all) {
+      if (transaction.getDirection() != Direction.SENT) {
+        continue;
+      }
+
+      Payee  payee = transaction.getPayee();
+      String key   = payeeKey(payee);
+      if (key == null || !seen.add(key)) {
+        continue;
+      }
+
+      payees.add(payee);
+      if (payees.size() == MAX_RECENT_RECIPIENTS) {
+        break;
+      }
+    }
+
+    return payees;
+  }
+
+  /** Identity for de-duplication: a contact by id, an external destination by its address. */
+  private static @Nullable String payeeKey(@NonNull Payee payee) {
+    if (payee.hasRecipientId()) {
+      return "id:" + payee.requireRecipientId().serialize();
+    } else if (payee.hasPublicAddress()) {
+      return "addr:" + payee.requireLightningAddress().getPaymentAddress();
+    } else {
+      return null;
+    }
+  }
+
+  private void bindRecentRecipients(@NonNull List<Payee> payees) {
+    recentContainer.removeAllViews();
+
+    for (Payee payee : payees) {
+      TextView row = (TextView) LayoutInflater.from(requireContext())
+                                              .inflate(R.layout.payment_recipient_selection_recent_item, recentContainer, false);
+
+      if (payee.hasRecipientId()) {
+        RecipientId recipientId = payee.requireRecipientId();
+        row.setText(Recipient.resolved(recipientId).getDisplayName(requireContext()));
+        row.setOnClickListener(v -> createPaymentOrShowWarningDialog(recipientId));
+      } else {
+        String address = payee.requireLightningAddress().getPaymentAddress();
+        row.setText(address);
+        row.setOnClickListener(v -> onSendToAddressClicked(address));
+      }
+
+      recentContainer.addView(row);
+    }
+
+    setRecentsVisible(!payees.isEmpty() && TextUtils.isEmpty(contactFilterView.getQuery()));
+  }
+
+  private void setRecentsVisible(boolean visible) {
+    recentHeader.setVisibility(visible ? View.VISIBLE : View.GONE);
+    recentContainer.setVisibility(visible ? View.VISIBLE : View.GONE);
   }
 
   private void createPayment(@NonNull RecipientId recipientId) {

--- a/app/src/main/res/layout/payment_recipient_selection_fragment.xml
+++ b/app/src/main/res/layout/payment_recipient_selection_fragment.xml
@@ -53,6 +53,30 @@
             tools:text="Send to someone@radar.cash"
             tools:visibility="visible" />
 
+        <TextView
+            android:id="@+id/payment_recipient_selection_fragment_recent_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/dsl_settings_gutter"
+            android:layout_marginRight="@dimen/dsl_settings_gutter"
+            android:paddingTop="8dp"
+            android:paddingBottom="4dp"
+            android:text="@string/PaymentRecipientSelectionFragment__recent"
+            android:textAppearance="@style/Signal.Text.Body"
+            android:textColor="@color/signal_text_secondary"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <LinearLayout
+            android:id="@+id/payment_recipient_selection_fragment_recents"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/dsl_settings_gutter"
+            android:layout_marginRight="@dimen/dsl_settings_gutter"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
         <FrameLayout
             android:id="@+id/contact_selection_list_fragment_holder"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/payment_recipient_selection_recent_item.xml
+++ b/app/src/main/res/layout/payment_recipient_selection_recent_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- One entry in the "Recent" list on the New payment screen: someone this wallet has paid before. -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground"
+    android:drawablePadding="16dp"
+    android:gravity="center_vertical"
+    android:minHeight="56dp"
+    android:paddingHorizontal="8dp"
+    android:textAppearance="@style/Signal.Text.BodyLarge"
+    app:drawableStartCompat="@drawable/symbol_bitcoin_24"
+    tools:text="Alice" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6086,6 +6086,8 @@
 
     <!-- PaymentRecipientSelectionFragment -->
     <string name="PaymentRecipientSelectionFragment__new_payment">New payment</string>
+    <!-- Header above the list of people this wallet has recently paid, on the new-payment screen -->
+    <string name="PaymentRecipientSelectionFragment__recent">Recent</string>
     <!-- Row shown beneath the search field when the typed text looks like a lightning address; tapping it sends to that address. %1$s is the address. -->
     <string name="PaymentRecipientSelectionFragment__send_to_s">Send to %1$s</string>
 


### PR DESCRIPTION
iOS's send screen carries a "Recent" section listing people this wallet has paid, backed by outgoing payment history. Android's had only the contact list and the typed-address row, so paying the same person twice meant searching for them again — or re-pasting an external address that is nowhere in the contact list at all.

Recents are read from the payments table, filtered to outgoing, de-duplicated and capped at five, newest first. De-duplication is by contact id where the payee is a contact and by destination string otherwise, so paying the same person twice does not fill the section, and an external lightning address still gets an entry.

Tapping a contact goes through createPaymentOrShowWarningDialog, the same eligibility check the contact list uses, rather than jumping straight into the amount screen — so a recent recipient who has since turned payments off is handled identically to any other. Tapping an external destination reuses the send-to-address path.

The section hides as soon as anything is typed, so filtered contact results are never shown alongside an unfiltered recents list.

The query runs off the main thread; ContactFilterView gains a small getter for its current text, which the visibility rule needs.

Verified: :Signal-Android:compilePlayProdDebugJavaWithJavac.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
