### PR TITLE
Let users ask someone to activate payments

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -329,10 +329,13 @@ public class AttachmentManager {
                        intent.putExtra(PaymentsActivity.EXTRA_PAYMENTS_STARTING_ACTION, R.id.action_directly_to_createPayment);
                        intent.putExtra(PaymentsActivity.EXTRA_STARTING_ARGUMENTS, new CreatePaymentFragmentArgs.Builder(new PayeeParcelable(recipient.getId())).setFinishOnConfirm(true).build().toBundle());
                        fragment.startActivity(intent);
-                     } else if (RemoteConfig.paymentsRequestActivateFlow()) {
-                       showRequestToActivatePayments(fragment.requireContext(), recipient);
                      } else {
-                       RecipientHasNotEnabledPaymentsDialog.show(fragment.requireContext());
+                       // Always offer to ask. This used to sit behind
+                       // RemoteConfig.paymentsRequestActivateFlow, whose key
+                       // ("android.payments.requestActivateFlow") defaults to false and is served by
+                       // Signal's config, so for Radar it was never on and the user only ever saw a
+                       // dead-end dialog. iOS offers the request unconditionally.
+                       showRequestToActivatePayments(fragment.requireContext(), recipient);
                      }
                    });
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/PaymentRecipientSelectionFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/PaymentRecipientSelectionFragment.java
@@ -30,6 +30,7 @@ import org.thoughtcrime.securesms.payments.CanNotSendPaymentDialog;
 import org.thoughtcrime.securesms.payments.LightningAddress;
 import org.thoughtcrime.securesms.payments.PaymentsAddressException;
 import org.thoughtcrime.securesms.payments.preferences.model.PayeeParcelable;
+import org.thoughtcrime.securesms.mms.AttachmentManager;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientId;
 import org.thoughtcrime.securesms.recipients.ui.findby.FindByActivity;
@@ -228,7 +229,9 @@ public class PaymentRecipientSelectionFragment extends LoggingFragment implement
                          showWarningDialog(recipientId);
                          break;
                        case NOT_ENABLED:
-                         RecipientHasNotEnabledPaymentsDialog.show(requireContext());
+                         // Offer to ask them to turn payments on, rather than the OK-only dead end
+                         // this used to show. Same dialog the conversation attachment menu uses.
+                         AttachmentManager.showRequestToActivatePayments(requireContext(), Recipient.resolved(recipientId));
                          break;
                      }
                    });


### PR DESCRIPTION
Hitting a recipient who has not turned payments on was a dead end. iOS shows an action sheet with a "Send request" button that messages them; Android showed an OK-only alert.

Two separate reasons for that, both fixed here:

The payments-tab send flow had no request action at all — PaymentEligibility NOT_ENABLED went straight to RecipientHasNotEnabledPaymentsDialog, which offers nothing but OK. It now shows the same request dialog the conversation attachment menu already had.

That conversation path could offer the request, but only when RemoteConfig.paymentsRequestActivateFlow was true. Its key, "android.payments.requestActivateFlow", defaults to false and is served by Signal's remote config — which will never enable a MobileCoin-era payments flag for Radar. So in practice that branch was dead and users fell through to the same OK-only dialog. The gate is removed; iOS has no equivalent flag.

Deliberately NOT ported: iOS also re-fetches the sender's Lightning profile with retries at 0/3/8s when a "payments activated" message arrives, and auto-retries the send. That exists because iOS reads a cached profile. Android does not cache it — ProfileUtil.getAddressForRecipient fetches the versioned profile from the network on every attempt, and nothing persists a payment address on the Recipient (checked by grep). So the staleness that retry works around does not occur here, and the next send attempt already sees the new state. Auto-resuming the send flow would be a UX addition rather than a fix, and is left out.

Verified: :Signal-Android:compilePlayProdDebugJavaWithJavac. RecipientHasNotEnabledPaymentsDialog is still used by the confirm and create-payment screens, where there is no recipient to ask, so it stays.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
