### PR TITLE
Support paying BOLT11 invoices

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/BreezSdkWrapper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/BreezSdkWrapper.kt
@@ -146,19 +146,46 @@ class BreezSdkWrapper(ledger: BreezSdk?) {
   }
 
   /**
-   * Prepares an LNURL/lightning-address payment for [amount] sats, returning the Breez quote
-   * (which carries the real network [PrepareLnurlPayResponse.feeSats]). Throws
-   * [UnsupportedOperationException] for non-LNURL inputs.
+   * A payment quote from Breez, whichever kind of destination produced it. Both variants carry the
+   * real network fee, so callers never have to know which shape they are holding.
    */
-  private fun prepareLnurl(address: String, amount: BigInteger): PrepareLnurlPayResponse {
-    val inputType = runBlocking { sdk!!.parse(address) }
+  private sealed class PreparedPayment {
+    abstract val feeSats: BigInteger
+
+    data class Lnurl(val response: PrepareLnurlPayResponse) : PreparedPayment() {
+      override val feeSats: BigInteger get() = response.feeSats.toLong().toBigInteger()
+    }
+
+    data class Bolt11(val response: PrepareSendPaymentResponse) : PreparedPayment() {
+      override val feeSats: BigInteger
+        get() = when (val method = response.paymentMethod) {
+          // A Spark transfer fee, when present, is what actually gets charged; the lightning fee is
+          // the fallback for a payment that leaves the Spark network.
+          is SendPaymentMethod.Bolt11Invoice -> (method.sparkTransferFeeSats ?: method.lightningFeeSats).toLong().toBigInteger()
+          else                               -> BigInteger.ZERO
+        }
+    }
+  }
+
+  /**
+   * Prepares a payment to [destination] for [amount] sats, returning the Breez quote (which carries
+   * the real network fee).
+   *
+   * [destination] is whatever the user gave us — a lightning address, an LNURL, or a BOLT11
+   * invoice — and the SDK's own parser decides which it is rather than this class guessing.
+   * Throws [UnsupportedOperationException] for destinations Radar does not send to.
+   */
+  private fun prepare(destination: String, amount: BigInteger): PreparedPayment {
+    val sdk = this.sdk ?: throw IllegalStateException("Breez SDK is not available")
+    val inputType = runBlocking { sdk.parse(destination) }
 
     // Breez SDK 0.14.0: `amountSats: ULong` → `amount: BigInteger`;
     // `optionalValidateSuccessActionUrl` → named `validateSuccessActionUrl: Boolean?`.
     val payRequest: LnurlPayRequestDetails = when (inputType) {
       is InputType.LightningAddress -> inputType.v1.payRequest
       is InputType.LnurlPay         -> inputType.v1
-      else                          -> throw UnsupportedOperationException()
+      is InputType.Bolt11Invoice    -> return prepareBolt11(sdk, inputType.v1, amount)
+      else                          -> throw UnsupportedOperationException("Unsupported payment destination")
     }
 
     val req = PrepareLnurlPayRequest(
@@ -167,34 +194,80 @@ class BreezSdkWrapper(ledger: BreezSdk?) {
       comment = null,
       validateSuccessActionUrl = true
     )
-    return runBlocking { sdk!!.prepareLnurlPay(req) }
+    return PreparedPayment.Lnurl(runBlocking { sdk.prepareLnurlPay(req) })
   }
 
   /**
-   * The real network fee for sending [amount] sats to [address], obtained from the Breez
+   * Prepares a BOLT11 invoice.
+   *
+   * An invoice may carry its own amount, in which case that amount is what gets paid and a
+   * caller-supplied one is rejected by the SDK. [amount] is therefore only forwarded for an
+   * amountless invoice, where the sender is the one choosing. Mirrors iOS `prepareOutgoingPayment`.
+   *
+   * When the invoice does carry an amount we refuse to proceed unless it matches what the caller
+   * asked for. The user confirmed a specific number on the previous screen; quietly paying the
+   * invoice's amount instead would let a pasted invoice spend more than was authorised.
+   */
+  private fun prepareBolt11(sdk: BreezSdk, details: Bolt11InvoiceDetails, amount: BigInteger): PreparedPayment.Bolt11 {
+    val invoiceSats: BigInteger? = details.amountMsat?.let { BigInteger.valueOf((it / 1000uL).toLong()) }
+
+    if (invoiceSats != null && invoiceSats != amount) {
+      throw InvoiceAmountMismatchException(invoiceSats, amount)
+    }
+
+    val request = PrepareSendPaymentRequest(
+      paymentRequest = PaymentRequest.Input(details.invoice.bolt11),
+      amount = if (invoiceSats == null) amount.toLong().toBigInteger() else null
+    )
+    return PreparedPayment.Bolt11(runBlocking { sdk.prepareSendPayment(request) })
+  }
+
+  /**
+   * Thrown when a BOLT11 invoice specifies an amount that differs from the one the user entered.
+   * Carries both so a caller can tell the user what the invoice actually asks for.
+   */
+  class InvoiceAmountMismatchException(val invoiceSats: BigInteger, val requestedSats: BigInteger) :
+    IllegalArgumentException("Invoice is for $invoiceSats sats but $requestedSats sats was requested")
+
+  /** The amount a BOLT11 invoice asks for in sats, or null if it is amountless or unparseable. */
+  fun bolt11AmountSats(invoice: String): BigInteger? {
+    val sdk = this.sdk ?: return null
+    return runCatching {
+      val parsed = runBlocking { sdk.parse(invoice) }
+      (parsed as? InputType.Bolt11Invoice)?.v1?.amountMsat?.let { BigInteger.valueOf((it / 1000uL).toLong()) }
+    }.getOrNull()
+  }
+
+  /**
+   * The real network fee for sending [amount] sats to [destination], obtained from the Breez
    * prepared-payment quote. Matches the fee that will actually be charged (and later shown in
    * payment details), unlike the coarser `recommendedFees()` estimate used by iOS's confirm screen.
    */
-  fun getLnurlFee(address: String, amount: BigInteger): Money.Satoshi {
+  fun getLnurlFee(destination: String, amount: BigInteger): Money.Satoshi {
     if (sdk == null) return Money.Satoshi.ZERO
-    return Money.satoshi(prepareLnurl(address, amount).feeSats.toLong().toBigInteger())
+    return Money.satoshi(prepare(destination, amount).feeSats)
   }
 
   /** Result of sending a payment: the serialized response plus the actual network fee charged. */
   data class SendPaymentResult(val response: ByteArray, val feeSats: BigInteger)
 
-  fun sendPayment(address: String, amount: BigInteger): SendPaymentResult {
-    val prepareResponse = prepareLnurl(address, amount)
+  fun sendPayment(destination: String, amount: BigInteger): SendPaymentResult {
+    val sdk = this.sdk ?: throw IllegalStateException("Breez SDK is not available")
 
     // Capture the real fee from the prepared payment so it can be persisted on the
-    // transaction. Mirrors iOS, which stores `prepareLnurlPay().feeSats` as the payment fee.
-    val feeSats = prepareResponse.feeSats.toLong().toBigInteger()
-
-    val response = runBlocking { sdk!!.lnurlPay(LnurlPayRequest(prepareResponse)) }
-
-    // Dual-format receipt: raw uniffi bytes (readable by Radar iOS) + a version-stable proto tail
-    // that survives breez_sdk_spark upgrades. See ReceiptCodec.
-    return SendPaymentResult(ReceiptCodec.encode(response), feeSats)
+    // transaction. Mirrors iOS, which stores the prepared quote's fee as the payment fee.
+    return when (val prepared = prepare(destination, amount)) {
+      is PreparedPayment.Lnurl -> {
+        val response = runBlocking { sdk.lnurlPay(LnurlPayRequest(prepared.response)) }
+        // Dual-format receipt: raw uniffi bytes (readable by Radar iOS) + a version-stable proto
+        // tail that survives breez_sdk_spark upgrades. See ReceiptCodec.
+        SendPaymentResult(ReceiptCodec.encode(response), prepared.feeSats)
+      }
+      is PreparedPayment.Bolt11 -> {
+        val response = runBlocking { sdk.sendPayment(SendPaymentRequest(prepared.response)) }
+        SendPaymentResult(ReceiptCodec.encode(response), prepared.feeSats)
+      }
+    }
   }
 
   /** The currently-registered lightning-address username, or null if none/unavailable. */

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/LightningAddress.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/LightningAddress.kt
@@ -55,10 +55,46 @@ class LightningAddress internal constructor(val paymentAddress: String, val lnur
       }
     }
 
+    /**
+     * Whether [input] looks like a BOLT11 invoice: the bech32 human-readable part for Lightning is
+     * `ln` plus a network prefix (`lnbc`, `lntb`, `lntbs`, `lnbcrt`). Deliberately loose — the SDK
+     * does the real parsing; this only decides which shape to build.
+     */
+    @JvmStatic
+    fun looksLikeBolt11Invoice(input: String): Boolean {
+      val trimmed = input.trim().removePrefix("lightning:").removePrefix("LIGHTNING:")
+      return trimmed.length > 20 && trimmed.lowercase().startsWith("ln") && !trimmed.contains("@")
+    }
+
+    /**
+     * A destination that is already a BOLT11 invoice. The invoice *is* the payment request, so
+     * there is no LNURL to derive: both fields carry it, which keeps `lightning:<invoice>` correct
+     * for the share/QR path and lets the whole send pipeline continue to carry a single type.
+     */
+    @JvmStatic
+    fun fromBolt11(invoice: String): LightningAddress {
+      val trimmed = invoice.trim().removePrefix("lightning:").removePrefix("LIGHTNING:")
+      return LightningAddress(trimmed, trimmed)
+    }
+
+    /**
+     * Parses a user-supplied destination into a [LightningAddress], accepting either a
+     * `user@host` lightning address or a BOLT11 invoice.
+     *
+     * This is the single entry point every deserialization path already funnels through
+     * (PaymentSendJob's job data, PayeeParcelable, PaymentTable rows), so teaching it about
+     * invoices is what lets a BOLT11 destination survive a round trip through any of them.
+     */
     @Throws(AddressException::class)
     fun fromLightningAddress(lightningAddress: String): LightningAddress {
+      if (looksLikeBolt11Invoice(lightningAddress)) {
+        return fromBolt11(lightningAddress)
+      }
       try {
         val lnParts = lightningAddress.split("@")
+        if (lnParts.size != 2 || lnParts[0].isEmpty() || lnParts[1].isEmpty()) {
+          throw AddressException("Not a lightning address: expected user@host")
+        }
         val lnurl = Bech32.encode(Bech32.Bech32Data("lnurl",
           Bech32.convert(
             "https://${lnParts[1]}/.well-known/lnurlp/${lnParts[0]}".toByteArray(Charsets.UTF_8), 8, 5, true)
@@ -100,6 +136,8 @@ class LightningAddress internal constructor(val paymentAddress: String, val lnur
           }
           // already a "user@host" lightning address
           serialized.contains("@") -> serialized
+          // a BOLT11 invoice — the payment request itself, nothing to derive
+          looksLikeBolt11Invoice(serialized) -> return fromBolt11(serialized)
           else -> throw AddressException("Unrecognized lightning payment address")
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/ReceiptCodec.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/ReceiptCodec.kt
@@ -7,6 +7,9 @@ package org.thoughtcrime.securesms.payments
 
 import breez_sdk_spark.ByteBuffer
 import breez_sdk_spark.FfiConverterTypeLnurlPayResponse
+import breez_sdk_spark.FfiConverterTypeSendPaymentResponse
+import breez_sdk_spark.Payment
+import breez_sdk_spark.SendPaymentResponse
 import breez_sdk_spark.LnurlPayResponse
 import breez_sdk_spark.PaymentDetails
 import breez_sdk_spark.PaymentStatus
@@ -61,6 +64,9 @@ object ReceiptCodec {
 
   /** Tail magic: "RDRCPT" + 2-digit structure version. Bump the digits only if the footer layout changes. */
   private val MAGIC = "RDRCPT01".toByteArray(Charsets.US_ASCII)
+
+  /** Leading marker for a BOLT11 send receipt, matching the one Radar iOS writes. */
+  private val BOLT11_MAGIC = "BOLT".toByteArray(Charsets.US_ASCII)
   private const val LEN_SIZE = 4
   private val FOOTER_SIZE = LEN_SIZE + MAGIC.size
 
@@ -84,10 +90,44 @@ object ReceiptCodec {
     return uniffiBytes + proto + footer.array()
   }
 
+  /**
+   * Serializes the response from paying a BOLT11 invoice.
+   *
+   * Prefixed with [BOLT11_MAGIC] before the uniffi bytes, matching the marker Radar iOS writes, so
+   * a reader can tell a SendPaymentResponse from an LnurlPayResponse — the two are different
+   * uniffi layouts and would otherwise be indistinguishable. The proto tail is identical either
+   * way and remains the authoritative part for us.
+   */
+  @JvmStatic
+  fun encode(response: SendPaymentResponse): ByteArray {
+    val size = FfiConverterTypeSendPaymentResponse.allocationSize(response)
+    val nioBuffer = java.nio.ByteBuffer.allocate(size.toInt())
+    FfiConverterTypeSendPaymentResponse.write(response, ByteBuffer(nioBuffer))
+    val uniffiBytes = nioBuffer.array().copyOf(nioBuffer.position())
+
+    val proto = toProto(fromSdk(response)).encode()
+    val footer = java.nio.ByteBuffer.allocate(FOOTER_SIZE)
+    footer.putInt(proto.size)
+    footer.put(MAGIC)
+
+    return BOLT11_MAGIC + uniffiBytes + proto + footer.array()
+  }
+
   /** Decodes a receipt blob from any supported generation, or null if nothing can read it. */
   @JvmStatic
   fun decode(receipt: ByteArray): ReceiptData? {
     parseTail(receipt)?.let { return it }
+
+    if (receipt.size > BOLT11_MAGIC.size && receipt.copyOf(BOLT11_MAGIC.size).contentEquals(BOLT11_MAGIC)) {
+      // A tail-less BOLT11 receipt, i.e. one written by Radar iOS.
+      try {
+        val payload = receipt.copyOfRange(BOLT11_MAGIC.size, receipt.size)
+        var input = ByteBuffer(java.nio.ByteBuffer.wrap(payload))
+        return fromSdk(FfiConverterTypeSendPaymentResponse.read(input))
+      } catch (e: Throwable) {
+        Log.d(TAG, "Receipt carried the BOLT marker but did not parse as a SendPaymentResponse", e)
+      }
+    }
 
     try {
       return fromSdk(deserializeLnurlPayResponse(receipt))
@@ -110,8 +150,13 @@ object ReceiptCodec {
 
   /** Maps an in-memory SDK response to the fields we persist. */
   @JvmStatic
-  fun fromSdk(response: LnurlPayResponse): ReceiptData {
-    val payment = response.payment
+  fun fromSdk(response: LnurlPayResponse): ReceiptData = fromPayment(response.payment)
+
+  @JvmStatic
+  fun fromSdk(response: SendPaymentResponse): ReceiptData = fromPayment(response.payment)
+
+  @JvmStatic
+  fun fromPayment(payment: Payment): ReceiptData {
     val (identifier, detailsType) = when (val details = payment.details) {
       is PaymentDetails.Lightning -> details.htlcDetails.paymentHash to ReceiptDetailsType.LIGHTNING
       is PaymentDetails.Deposit -> details.txId to ReceiptDetailsType.DEPOSIT

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/create/CreatePaymentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/create/CreatePaymentFragment.java
@@ -21,6 +21,11 @@ import androidx.transition.TransitionManager;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
+import org.thoughtcrime.securesms.payments.LightningAddress;
+import org.signal.core.util.concurrent.SimpleTask;
+import org.thoughtcrime.securesms.payments.Payee;
+import org.thoughtcrime.securesms.payments.preferences.model.PayeeParcelable;
 import org.thoughtcrime.securesms.LoggingFragment;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiEditText;
@@ -82,6 +87,8 @@ public class CreatePaymentFragment extends LoggingFragment {
     CreatePaymentFragmentArgs      arguments = CreatePaymentFragmentArgs.fromBundle(requireArguments());
     CreatePaymentViewModel.Factory factory   = new CreatePaymentViewModel.Factory(arguments.getPayee(), arguments.getNote());
     CreatePaymentViewModel         viewModel = new ViewModelProvider(Navigation.findNavController(view).getViewModelStoreOwner(R.id.payments_create), factory).get(CreatePaymentViewModel.class);
+
+    seedAmountFromInvoiceIfFixed(arguments.getPayee(), viewModel);
 
     constraintLayout = view.findViewById(R.id.create_payment_fragment_amount_header);
     request          = view.findViewById(R.id.create_payment_fragment_request);
@@ -236,6 +243,33 @@ public class CreatePaymentFragment extends LoggingFragment {
 
   private void updateRequestAmountButtons(boolean isValidAmount) {
     request.setEnabled(isValidAmount);
+  }
+
+  /**
+   * A BOLT11 invoice may specify its own amount, in which case that is the only amount the network
+   * will accept. Fill it in so the user is confirming the real figure rather than guessing — and so
+   * the send is not refused later by the mismatch guard in BreezSdkWrapper.
+   *
+   * <p>Runs off the main thread: reading the amount means parsing the invoice through the SDK.
+   */
+  private void seedAmountFromInvoiceIfFixed(@NonNull PayeeParcelable payeeParcelable, @NonNull CreatePaymentViewModel viewModel) {
+    Payee payee = payeeParcelable.getPayee();
+    if (!payee.hasPublicAddress()) {
+      return;
+    }
+
+    String destination = payee.requireLightningAddress().getPaymentAddress();
+    if (!LightningAddress.looksLikeBolt11Invoice(destination)) {
+      return;
+    }
+
+    SimpleTask.run(getViewLifecycleOwner().getLifecycle(),
+                   () -> SignalStore.payments().breezSdkWrapperLatest().bolt11AmountSats(destination),
+                   amountSats -> {
+                     if (amountSats != null && amountSats.signum() > 0) {
+                       viewModel.setAmount(Money.satoshi(amountSats));
+                     }
+                   });
   }
 
   private void updatePayAmountButtons(boolean isValidAmount) {

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/create/CreatePaymentViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/create/CreatePaymentViewModel.java
@@ -131,6 +131,19 @@ public class CreatePaymentViewModel extends ViewModel {
     });
   }
 
+  /**
+   * Seeds the amount from a destination that dictates it — a BOLT11 invoice carrying its own
+   * amount. The user does not get to choose in that case: the invoice does, and sending anything
+   * else would be refused by the network.
+   */
+  void setAmount(@NonNull Money money) {
+    inputState.update(s -> {
+      final Optional<FiatMoney> fiat = s.getExchangeRate().flatMap(r -> r.exchange(money));
+
+      return s.updateAmount(money.requireBitcoin().toSatoshiBigInteger().toString(), "0", money, fiat);
+    });
+  }
+
   void toggleMoneyInputTarget() {
     inputState.update(s -> s.updateInputTarget(s.getInputTarget().next()));
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/PaymentRecipientSelectionFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/PaymentRecipientSelectionFragment.java
@@ -113,20 +113,38 @@ public class PaymentRecipientSelectionFragment extends LoggingFragment implement
   }
 
   /**
-   * Mirrors iOS's inline "find by …" section: when the typed query looks like a lightning address
-   * (e.g. {@code name@radar.cash}), surface a tappable row that sends directly to that address.
+   * Mirrors iOS's inline "find by …" section: when the typed query looks like a payable
+   * destination, surface a tappable row that sends straight to it.
+   *
+   * <p>Two shapes are accepted: a lightning address ({@code name@radar.cash}) and a BOLT11 invoice
+   * ({@code lnbc…}), the latter typically arriving via the paste button. An invoice is far too long
+   * to show in full, so it is abbreviated for display while the full string is what gets sent.
    */
   private void updateSendToAddressRow(@Nullable String filter) {
     String query = filter != null ? filter.trim() : "";
 
-    if (LIGHTNING_ADDRESS_SHAPE.matcher(query).matches()) {
-      sendToAddressRow.setText(getString(R.string.PaymentRecipientSelectionFragment__send_to_s, query));
+    boolean isAddress = LIGHTNING_ADDRESS_SHAPE.matcher(query).matches();
+    boolean isInvoice = LightningAddress.looksLikeBolt11Invoice(query);
+
+    if (isAddress || isInvoice) {
+      String display = isInvoice ? abbreviate(query) : query;
+      sendToAddressRow.setText(getString(R.string.PaymentRecipientSelectionFragment__send_to_s, display));
       sendToAddressRow.setVisibility(View.VISIBLE);
       sendToAddressRow.setOnClickListener(v -> onSendToAddressClicked(query));
     } else {
       sendToAddressRow.setVisibility(View.GONE);
       sendToAddressRow.setOnClickListener(null);
     }
+  }
+
+  /** Shortens a long destination to head…tail for display. Matches iOS's 10/9 split. */
+  private static @NonNull String abbreviate(@NonNull String value) {
+    final int prefix = 10;
+    final int suffix = 9;
+    if (value.length() <= prefix + suffix + 1) {
+      return value;
+    }
+    return value.substring(0, prefix) + "\u2026" + value.substring(value.length() - suffix);
   }
 
   private void onSendToAddressClicked(@NonNull String query) {


### PR DESCRIPTION
Android could only send to a lightning address. A pasted invoice was rejected three separate times over: the send screen only surfaced its "Send to" row for a user@host shape, LightningAddress parsed by splitting on "@", and BreezSdkWrapper.prepareLnurl threw UnsupportedOperationException for anything that was not an LNURL. That meant an Android user could not pay an invoice at all — including the one Radar iOS's own Add Funds screen shows in its QR.

The pipeline already carried a single destination type from the send screen through PayeeParcelable, PaymentSendJob's serialized job data and PaymentTable rows, so the change is to teach that type about invoices rather than to add a parallel one:

- LightningAddress.fromLightningAddress now recognises a BOLT11 invoice and builds a form where the invoice is both the payment request and the lightning: URI. Because every deserialization path already funnels through that one method, an invoice destination survives a round trip through all of them without touching any of them.
- BreezSdkWrapper stops pattern-matching the string itself and asks the SDK's parser, then routes: LnurlPay/LightningAddress as before, Bolt11Invoice through prepareSendPayment/sendPayment. A small sealed PreparedPayment type means callers keep asking for "the fee" without knowing which kind they hold.
- ReceiptCodec gains an encoder for the SendPaymentResponse a BOLT11 payment returns, prefixed with the same "BOLT" marker iOS writes so the two uniffi layouts stay distinguishable, and a matching decode branch. The proto tail is unchanged and remains the authoritative part, so decode() and getIdentifierFromReceipt keep working.

On amounts, which is where this could go quietly wrong: an invoice may carry its own amount, and the SDK then pays *that*, not what the user typed. Left alone, a pasted invoice could spend more than was confirmed on the previous screen. Two things prevent that. The create-payment screen reads the invoice's amount and fills it in, so the user confirms the real figure; and prepareBolt11 refuses outright if an invoice's amount does not match the requested one, rather than letting the invoice win.

Verified: :Signal-Android:compilePlayProdDebugKotlin and …JavaWithJavac, plus a trace of the whole path — UI accepts, fromLightningAddress builds the invoice form, PaymentSendJob's KEY_ADDRESS round-trips it, Wallet.sendPayment hands it to the wrapper, and sdk.parse routes it to the BOLT11 branch. Types checked against the breez_sdk_spark 0.18.0 bindings: PrepareSendPaymentRequest takes a PaymentRequest.Input, and the fee is the Spark transfer fee where present, falling back to the lightning fee.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
