### PR TITLE
Allow restoring a 24-word recovery phrase

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/Entropy.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/Entropy.java
@@ -31,7 +31,10 @@ public final class Entropy {
     if (bytes == null) {
       return null;
     }
-    if (bytes.length == PaymentsConstants.PAYMENTS_ENTROPY_LENGTH) {
+    // Accept every restorable length, not just the one we mint at: a wallet created before the
+    // switch to a 12-word phrase holds 32 bytes, and rejecting it here silently turned a valid
+    // recovery phrase into "no wallet".
+    if (PaymentsConstants.isSupportedPaymentsEntropyLength(bytes.length)) {
       return new Entropy(bytes);
     } else {
       Log.w(TAG, String.format(Locale.US, "Entropy was supplied of length %d and ignored", bytes.length), new Throwable());

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/backup/PaymentsRecoveryPasteFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/backup/PaymentsRecoveryPasteFragment.java
@@ -45,7 +45,7 @@ public class PaymentsRecoveryPasteFragment extends Fragment {
       String   mnemonic = input.getText().toString();
       String[] words    = mnemonic.split("\\s+");
 
-      if (words.length != PaymentsConstants.MNEMONIC_LENGTH) {
+      if (!PaymentsConstants.isSupportedMnemonicLength(words.length)) {
         showErrorDialog();
         return;
       }
@@ -57,7 +57,7 @@ public class PaymentsRecoveryPasteFragment extends Fragment {
   private void showErrorDialog() {
     new MaterialAlertDialogBuilder(requireContext())
                    .setTitle(R.string.PaymentsRecoveryPasteFragment__invalid_recovery_phrase)
-                   .setMessage(getString(R.string.PaymentsRecoveryPasteFragment__make_sure, PaymentsConstants.MNEMONIC_LENGTH))
+                   .setMessage(getString(R.string.PaymentsRecoveryPasteFragment__make_sure_12_or_24))
                    .setPositiveButton(android.R.string.ok, (dialog, which) -> dialog.dismiss())
                    .show();
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/backup/entry/PaymentsRecoveryEntryFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/backup/entry/PaymentsRecoveryEntryFragment.java
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.Navigation;
 
+import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.textfield.MaterialAutoCompleteTextView;
 import com.google.android.material.textfield.TextInputLayout;
 
@@ -21,6 +22,7 @@ import org.thoughtcrime.securesms.payments.Mnemonic;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.navigation.SafeNavigation;
 import org.thoughtcrime.securesms.util.text.AfterTextChanged;
+import org.whispersystems.signalservice.api.payments.PaymentsConstants;
 
 public class PaymentsRecoveryEntryFragment extends Fragment {
 
@@ -35,11 +37,24 @@ public class PaymentsRecoveryEntryFragment extends Fragment {
     TextInputLayout                wrapper   = view.findViewById(R.id.payments_recovery_entry_fragment_word_wrapper);
     MaterialAutoCompleteTextView   word      = view.findViewById(R.id.payments_recovery_entry_fragment_word);
     View                           next      = view.findViewById(R.id.payments_recovery_entry_fragment_next);
+    MaterialButtonToggleGroup      wordCount = view.findViewById(R.id.payments_recovery_entry_fragment_word_count);
     PaymentsRecoveryEntryViewModel viewModel = new ViewModelProvider(this).get(PaymentsRecoveryEntryViewModel.class);
 
     toolbar.setNavigationOnClickListener(t -> Navigation.findNavController(view).popBackStack(R.id.paymentsHome, false));
 
+    // Phrase length switcher. Wallets created before the move to a 12-word phrase have 24 words,
+    // and their owners must be able to type them back in. Switching discards what has been entered
+    // so far (see PaymentsRecoveryEntryViewModel.setWordCount), so only offer it on the first word.
+    wordCount.check(viewModel.getWordCount() == 24 ? R.id.payments_recovery_entry_fragment_word_count_24
+                                                   : R.id.payments_recovery_entry_fragment_word_count_12);
+    wordCount.addOnButtonCheckedListener((group, checkedId, isChecked) -> {
+      if (isChecked) {
+        viewModel.setWordCount(checkedId == R.id.payments_recovery_entry_fragment_word_count_24 ? 24 : PaymentsConstants.MNEMONIC_LENGTH);
+      }
+    });
+
     viewModel.getState().observe(getViewLifecycleOwner(), state -> {
+      wordCount.setVisibility(state.getWordIndex() == 0 ? View.VISIBLE : View.GONE);
       message.setText(getString(R.string.PaymentsRecoveryEntryFragment__enter_word_d, state.getWordIndex() + 1));
       word.setHint(getString(R.string.PaymentsRecoveryEntryFragment__word_d, state.getWordIndex() + 1));
       wrapper.setError(state.canMoveToNext() || TextUtils.isEmpty(state.getCurrentEntry()) ? null : getString(R.string.PaymentsRecoveryEntryFragment__invalid_word));

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/backup/entry/PaymentsRecoveryEntryViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/backup/entry/PaymentsRecoveryEntryViewModel.java
@@ -14,6 +14,10 @@ public class PaymentsRecoveryEntryViewModel extends ViewModel {
 
   private Store<PaymentsRecoveryEntryViewState> state  = new Store<>(new PaymentsRecoveryEntryViewState());
   private SingleLiveEvent<Events>               events = new SingleLiveEvent<>();
+  /**
+   * Buffer for the phrase being entered. Length is switchable so a wallet created before the move
+   * to a 12-word phrase — whose owner holds 24 words — can still be recovered by hand.
+   */
   private String[]                              words  = new String[PaymentsConstants.MNEMONIC_LENGTH];
 
   @NonNull LiveData<PaymentsRecoveryEntryViewState> getState() {
@@ -28,6 +32,24 @@ public class PaymentsRecoveryEntryViewModel extends ViewModel {
     return words;
   }
 
+  int getWordCount() {
+    return words.length;
+  }
+
+  /**
+   * Switches the length of phrase being entered. Anything typed so far is discarded — the two
+   * lengths are different phrases, not a prefix of one another, so carrying words across would
+   * only produce a phrase the user did not mean. Mirrors iOS, which also resets on switch.
+   */
+  void setWordCount(int wordCount) {
+    if (!PaymentsConstants.isSupportedMnemonicLength(wordCount) || wordCount == words.length) {
+      return;
+    }
+
+    words = new String[wordCount];
+    state.update(s -> new PaymentsRecoveryEntryViewState(0, false, ""));
+  }
+
   void onWordChanged(@NonNull String entry) {
     state.update(s -> new PaymentsRecoveryEntryViewState(s.getWordIndex(), isValid(entry), entry));
   }
@@ -36,7 +58,7 @@ public class PaymentsRecoveryEntryViewModel extends ViewModel {
     state.update(s -> {
       words[s.getWordIndex()] = s.getCurrentEntry();
 
-      if (s.getWordIndex() == PaymentsConstants.MNEMONIC_LENGTH - 1) {
+      if (s.getWordIndex() == words.length - 1) {
         events.postValue(Events.GO_TO_CONFIRM);
         return new PaymentsRecoveryEntryViewState(0, isValid(words[0]), words[0]);
       } else {

--- a/app/src/main/res/layout/payments_recovery_entry_fragment.xml
+++ b/app/src/main/res/layout/payments_recovery_entry_fragment.xml
@@ -54,6 +54,33 @@
                 app:layout_constraintTop_toBottomOf="@id/payments_recovery_entry_fragment_title"
                 tools:text="Enter word 6" />
 
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/payments_recovery_entry_fragment_word_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/payments_recovery_entry_fragment_message"
+                app:selectionRequired="true"
+                app:singleSelection="true">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/payments_recovery_entry_fragment_word_count_12"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/PaymentsRecoveryEntryFragment__12_words" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/payments_recovery_entry_fragment_word_count_24"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/PaymentsRecoveryEntryFragment__24_words" />
+
+            </com.google.android.material.button.MaterialButtonToggleGroup>
+
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/payments_recovery_entry_fragment_word_wrapper"
                 android:layout_width="match_parent"
@@ -65,7 +92,7 @@
                 app:hintEnabled="false"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/payments_recovery_entry_fragment_message">
+                app:layout_constraintTop_toBottomOf="@id/payments_recovery_entry_fragment_word_count">
 
                 <com.google.android.material.textfield.MaterialAutoCompleteTextView
                     android:id="@+id/payments_recovery_entry_fragment_word"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5512,6 +5512,12 @@
     <string name="PaymentsRecoveryPasteFragment__next">Next</string>
     <string name="PaymentsRecoveryPasteFragment__invalid_recovery_phrase">Invalid recovery phrase</string>
     <string name="PaymentsRecoveryPasteFragment__make_sure">Make sure you\'ve entered %1$d words and try again.</string>
+    <!-- Error shown when a pasted recovery phrase is neither 12 nor 24 words long -->
+    <string name="PaymentsRecoveryPasteFragment__make_sure_12_or_24">Make sure you\'ve entered your full 12-word or 24-word recovery phrase and try again.</string>
+    <!-- Option to enter a 12-word recovery phrase -->
+    <string name="PaymentsRecoveryEntryFragment__12_words">12 words</string>
+    <!-- Option to enter a 24-word recovery phrase, for wallets created before the switch to 12 words -->
+    <string name="PaymentsRecoveryEntryFragment__24_words">24 words</string>
 
     <string name="PaymentsRecoveryStartFragment__learn_more__view" translatable="false">https://support.signal.org/hc/articles/360057625692#payments_wallet_view_passphrase</string>
     <string name="PaymentsRecoveryStartFragment__learn_more__restore" translatable="false">https://support.signal.org/hc/articles/360057625692#payments_wallet_restore_passphrase</string>

--- a/libsignal-service/src/main/java/org/whispersystems/signalservice/api/payments/PaymentsConstants.java
+++ b/libsignal-service/src/main/java/org/whispersystems/signalservice/api/payments/PaymentsConstants.java
@@ -4,8 +4,36 @@ public final class PaymentsConstants {
 
   private PaymentsConstants() {}
 
+  /** Entropy length used for wallets this client creates, i.e. a {@link #MNEMONIC_LENGTH} phrase. */
   public static final int PAYMENTS_ENTROPY_LENGTH = 16;
   public static final int MNEMONIC_LENGTH         = Math.round(PAYMENTS_ENTROPY_LENGTH * 0.75f);
   public static final int SHORT_FRACTION_LENGTH   = 4;
+
+  /**
+   * Entropy lengths this client can <em>restore</em>, newest first. New wallets are always minted at
+   * {@link #PAYMENTS_ENTROPY_LENGTH}, but wallets created before the switch to a 12-word phrase hold
+   * 32 bytes, and their owners must still be able to recover them.
+   */
+  public static final int[] SUPPORTED_PAYMENTS_ENTROPY_LENGTHS = { 16, 32 };
+
+  /** Recovery phrase word counts this client can restore, matching {@link #SUPPORTED_PAYMENTS_ENTROPY_LENGTHS}. */
+  public static final int[] SUPPORTED_MNEMONIC_LENGTHS = { 12, 24 };
+
+  public static boolean isSupportedPaymentsEntropyLength(int length) {
+    return contains(SUPPORTED_PAYMENTS_ENTROPY_LENGTHS, length);
+  }
+
+  public static boolean isSupportedMnemonicLength(int wordCount) {
+    return contains(SUPPORTED_MNEMONIC_LENGTHS, wordCount);
+  }
+
+  private static boolean contains(int[] values, int value) {
+    for (int candidate : values) {
+      if (candidate == value) {
+        return true;
+      }
+    }
+    return false;
+  }
 
 }

--- a/libsignal-service/src/main/java/org/whispersystems/signalservice/api/storage/AccountRecordExtensions.kt
+++ b/libsignal-service/src/main/java/org/whispersystems/signalservice/api/storage/AccountRecordExtensions.kt
@@ -18,7 +18,10 @@ import org.whispersystems.signalservice.internal.storage.protos.Payments
 
 fun AccountRecord.Builder.safeSetPayments(enabled: Boolean, entropy: ByteArray?): AccountRecord.Builder {
   val paymentsBuilder = Payments.Builder()
-  val entropyPresent = entropy != null && entropy.size == PaymentsConstants.PAYMENTS_ENTROPY_LENGTH
+  // Any restorable length, not just the one we mint at. A wallet recovered from a pre-12-word
+  // phrase holds 32 bytes; rejecting it here would drop the seed from the Storage Service record
+  // *and* write payments back as disabled, losing the wallet on the next restore.
+  val entropyPresent = entropy != null && PaymentsConstants.isSupportedPaymentsEntropyLength(entropy.size)
 
   paymentsBuilder.enabled(enabled && entropyPresent)
 


### PR DESCRIPTION
Wallets created before Radar moved to a 12-word phrase hold 32 bytes of entropy and print 24 words. Android could not take them back: the entropy length, the word count and every screen in the recovery flow were pinned to 16 bytes / 12 words, so a perfectly valid recovery phrase was rejected. iOS supports both lengths (9ab52abb5f) and offers a 12/24 switcher on its restore screen.

New wallets are still minted at 16 bytes. This only widens what can be *restored*:

- PaymentsConstants gains SUPPORTED_PAYMENTS_ENTROPY_LENGTHS {16, 32} and SUPPORTED_MNEMONIC_LENGTHS {12, 24} with membership helpers, so the two notions — what we generate vs what we accept — stop being the same constant.
- Entropy.fromBytes accepts either length instead of returning null, which is what turned a valid 32-byte seed into "no wallet".
- The paste screen accepts 12 or 24 words, with an error message that no longer names a single count.
- The word-by-word screen gains a 12/24 switcher, shown only on the first word. Switching resets the buffer, because the two lengths are different phrases rather than a prefix of one another — the same reset iOS performs.

The one non-obvious consequence, found by tracing where a restored seed travels rather than where it is entered: AccountRecordExtensions.safeSetPayments gated the Storage Service account record on the *mint* length. A restored 24-word wallet would have had its seed silently dropped from the record and payments written back as disabled — losing the wallet on the next restore, which is precisely the situation the user is already recovering from. That check now uses the supported-lengths helper too.

Everything downstream was already length-agnostic and was checked rather than assumed: the confirm and display screens size themselves from words.size(), restoreWallet decodes through Mnemonics.bip39EntropyFromMnemonic, and BreezSdkWrapper.connect re-encodes with bip39EntropyToMnemonic, so a 32-byte seed yields the 24-word mnemonic Spark expects.

Verified: :Signal-Android:compilePlayProdDebugKotlin and …JavaWithJavac.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
