### PR TITLE
Honour hide-balance on every displayed amount, not just the chat list

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ui/payment/PaymentMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ui/payment/PaymentMessageView.kt
@@ -80,7 +80,7 @@ class PaymentMessageView @JvmOverloads constructor(
       binding.paymentAmount.visible = true
       binding.paymentInprogress.visible = false
       binding.paymentAmount.setTextColor(quoteViewColorTheme.getForegroundColor(context))
-      binding.paymentAmount.setMoney(payment.amount, 0L, currencyTypefaceSpan)
+      binding.paymentAmount.setMoneyRespectingHiddenBalance(payment.amount, 0L, currencyTypefaceSpan)
     }
 
     ViewCompat.setBackgroundTintList(binding.paymentAmountLayout, ColorStateList.valueOf(quoteViewColorTheme.getBackgroundColor(context)))
@@ -126,7 +126,7 @@ class PaymentMessageView @JvmOverloads constructor(
     binding.paymentAmount.visible = true
     binding.paymentInprogress.visible = false
     binding.paymentAmount.setTextColor(quoteViewColorTheme.getForegroundColor(context))
-    binding.paymentAmount.setMoney(amount, 0L, currencyTypefaceSpan)
+    binding.paymentAmount.setMoneyRespectingHiddenBalance(amount, 0L, currencyTypefaceSpan)
 
     ViewCompat.setBackgroundTintList(binding.paymentAmountLayout, ColorStateList.valueOf(quoteViewColorTheme.getBackgroundColor(context)))
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/PinnedMessagesComponent.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/PinnedMessagesComponent.kt
@@ -270,7 +270,7 @@ fun getMessageMetadata(conversationMessage: ConversationMessage): Triple<SignalS
   } else if (message.hasSharedContact()) {
     Triple(SignalSymbols.Glyph.PERSON_CIRCLE, SpannableString(message.sharedContacts.first().name.givenName), false)
   } else if (message.isPaymentNotification && message.payment != null) {
-    Triple(SignalSymbols.Glyph.CREDIT_CARD, SpannableString(PaymentAmountFormatter.format(message.payment!!.amount)), false)
+    Triple(SignalSymbols.Glyph.CREDIT_CARD, SpannableString(PaymentAmountFormatter.formatRespectingHiddenBalance(message.payment!!.amount)), false)
   } else if (slide?.isVideoGif == true) {
     Triple(SignalSymbols.Glyph.GIF_RECTANGLE, SpannableString(stringResource(R.string.PinnedMessage__gif)), false)
   } else if (slide is ImageSlide && message.body.isEmpty()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/model/UnreadPayments.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/model/UnreadPayments.java
@@ -53,7 +53,7 @@ public abstract class UnreadPayments {
     public @NonNull String getDescription(@NonNull Context context) {
       if (recipient != null) {
         String amountString = SignalStore.payments().getBalanceHidden()
-                              ? "••••••"
+                              ? PaymentAmountFormatter.HIDDEN_AMOUNT
                               : PaymentAmountFormatter.format(amount);
         return context.getString(R.string.UnreadPayments__s_sent_you_s,
                                  recipient.getShortDisplayName(context),

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadBodyUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadBodyUtil.java
@@ -76,7 +76,7 @@ public final class ThreadBodyUtil {
 
   /**
    * Extracts a formatted amount string for the payment associated with a chat-list message.
-   * Returns `null` if the amount can't be resolved; "•••••" if the balance is hidden
+   * Returns `null` if the amount can't be resolved; the hidden-balance placeholder if the
    * (mirrors iOS `balanceHidden` masking from c90dd2d790).
    */
   private static @Nullable String formatPaymentAmount(@NonNull MmsMessageRecord record) {
@@ -93,7 +93,7 @@ public final class ThreadBodyUtil {
       return null;
     }
     if (SignalStore.payments().getBalanceHidden()) {
-      return "•••••";
+      return PaymentAmountFormatter.HIDDEN_AMOUNT;
     }
     // Single display layer decides sats vs BTC (mirrors MoneyView / iOS PaymentsFormat).
     return PaymentAmountFormatter.format(amount, FormatterOptions.builder(Locale.getDefault()).build());

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MmsMessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MmsMessageRecord.java
@@ -231,7 +231,7 @@ public class MmsMessageRecord extends MessageRecord {
     } else if (isLegacyMessage()) {
       return emphasisAdded(context.getString(R.string.MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported));
     } else if (isPaymentNotification() && payment != null) {
-      return new SpannableString(context.getString(R.string.MessageRecord__payment_s, PaymentAmountFormatter.format(payment.getAmount())));
+      return new SpannableString(context.getString(R.string.MessageRecord__payment_s, PaymentAmountFormatter.formatRespectingHiddenBalance(payment.getAmount())));
     } else if (isPaymentTombstone() || isPaymentNotification()) {
       MessageExtras extras = getMessageExtras();
 
@@ -242,7 +242,7 @@ public class MmsMessageRecord extends MessageRecord {
       if (amount == null) {
         return new SpannableString(context.getString(R.string.MessageRecord__payment_tombstone));
       } else {
-        return new SpannableString(context.getString(R.string.MessageRecord__payment_s, PaymentAmountFormatter.format(amount)));
+        return new SpannableString(context.getString(R.string.MessageRecord__payment_s, PaymentAmountFormatter.formatRespectingHiddenBalance(amount)));
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/MoneyView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/MoneyView.java
@@ -103,6 +103,35 @@ public final class MoneyView extends AppCompatTextView {
     setMoney(money, timestamp, (highlightCurrency ? new ForegroundColorSpan(ContextCompat.getColor(getContext(), R.color.payment_currency_code_foreground_color)) : null));
   }
 
+  /**
+   * Displays {@code money}, or {@link PaymentAmountFormatter#HIDDEN_AMOUNT} while the user has
+   * hidden their balance. For amounts that are being shown back to the user (a settled payment, a
+   * balance); the send-flow input keeps using {@link #setMoney} so the user can always see what
+   * they are typing.
+   */
+  public void setMoneyRespectingHiddenBalance(@NonNull Money money) {
+    setMoneyRespectingHiddenBalance(money, true, 0L);
+  }
+
+  /** @see #setMoneyRespectingHiddenBalance(Money) */
+  public void setMoneyRespectingHiddenBalance(@NonNull Money money, boolean highlightCurrency) {
+    setMoneyRespectingHiddenBalance(money, highlightCurrency, 0L);
+  }
+
+  /** @see #setMoneyRespectingHiddenBalance(Money) */
+  public void setMoneyRespectingHiddenBalance(@NonNull Money money, boolean highlightCurrency, long timestamp) {
+    setMoneyRespectingHiddenBalance(money, timestamp, (highlightCurrency ? new ForegroundColorSpan(ContextCompat.getColor(getContext(), R.color.payment_currency_code_foreground_color)) : null));
+  }
+
+  /** @see #setMoneyRespectingHiddenBalance(Money) */
+  public void setMoneyRespectingHiddenBalance(@NonNull Money money, long timestamp, @Nullable Object currencySpan) {
+    if (PaymentAmountFormatter.isBalanceHidden()) {
+      setText(PaymentAmountFormatter.HIDDEN_AMOUNT);
+      return;
+    }
+    setMoney(money, timestamp, currencySpan);
+  }
+
   public void setMoney(@NonNull Money money, long timestamp, @Nullable Object currencySpan) {
     // The sats-vs-BTC decision and all formatting live in PaymentAmountFormatter, the single
     // display layer. Every caller (home balance, chat bubble, history, send flow, chat-list

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/PaymentAmountFormatter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/PaymentAmountFormatter.java
@@ -29,7 +29,18 @@ public final class PaymentAmountFormatter {
 
   public static final String SATS_UNIT = "sats";
 
+  /**
+   * Placeholder rendered in place of an amount while the user has chosen to hide their balance.
+   * Single definition so every masked surface uses the same glyph run.
+   */
+  public static final String HIDDEN_AMOUNT = "\u2022\u2022\u2022\u2022\u2022\u2022";
+
   private PaymentAmountFormatter() {}
+
+  /** Whether amounts should currently be masked, i.e. the user has hidden their balance. */
+  public static boolean isBalanceHidden() {
+    return SignalStore.payments().getBalanceHidden();
+  }
 
   /** Whether the given amount should currently be rendered in sats. */
   public static boolean isSatsDisplay(@NonNull Money money) {
@@ -48,6 +59,25 @@ public final class PaymentAmountFormatter {
   /** Formats with default options, respecting the sats/BTC preference. */
   public static @NonNull String format(@NonNull Money money) {
     return format(money, FormatterOptions.defaults());
+  }
+
+  /**
+   * Formats respecting the sats/BTC preference <em>and</em> the hide-balance preference, returning
+   * {@link #HIDDEN_AMOUNT} while the balance is hidden.
+   *
+   * <p>Use this for any amount that is merely being <em>displayed</em> — a settled payment, a
+   * balance readout. Do <em>not</em> use it for an amount the user is actively entering or
+   * confirming: hiding the balance is about not shoulder-surfing your holdings, not about being
+   * unable to see what you are about to send. Mirrors the split iOS draws between
+   * {@code PaymentsFormat.formattedBalance} (masks) and {@code PaymentsFormat.format} (does not).
+   */
+  public static @NonNull String formatRespectingHiddenBalance(@NonNull Money money) {
+    return formatRespectingHiddenBalance(money, FormatterOptions.defaults());
+  }
+
+  /** @see #formatRespectingHiddenBalance(Money) */
+  public static @NonNull String formatRespectingHiddenBalance(@NonNull Money money, @NonNull FormatterOptions options) {
+    return isBalanceHidden() ? HIDDEN_AMOUNT : format(money, options);
   }
 
   /** Formats with the given options, respecting the sats/BTC preference. */

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/confirm/ConfirmPaymentAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/confirm/ConfirmPaymentAdapter.java
@@ -120,7 +120,7 @@ public class ConfirmPaymentAdapter extends MappingAdapter {
 
     public @NonNull CharSequence getInfoText(@NonNull Context context) {
       switch (status) {
-        case CONFIRM:    return context.getString(R.string.ConfirmPayment__balance_s, PaymentAmountFormatter.format(balance));
+        case CONFIRM:    return context.getString(R.string.ConfirmPayment__balance_s, PaymentAmountFormatter.formatRespectingHiddenBalance(balance));
         case SUBMITTING: return context.getString(R.string.ConfirmPayment__submitting_payment);
         case PROCESSING: return context.getString(R.string.ConfirmPayment__processing_payment);
         case DONE:       return context.getString(R.string.ConfirmPayment__payment_complete);

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/create/CreatePaymentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/create/CreatePaymentFragment.java
@@ -243,7 +243,7 @@ public class CreatePaymentFragment extends LoggingFragment {
   }
 
   private void updateBalance(@NonNull Money balance) {
-    String value = PaymentAmountFormatter.format(balance);
+    String value = PaymentAmountFormatter.formatRespectingHiddenBalance(balance);
     this.balance.setText(SpanUtil.boldSubstring(getString(R.string.CreatePaymentFragment__available_balance_s, value), value));
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/PaymentsHomeFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/PaymentsHomeFragment.java
@@ -33,6 +33,7 @@ import org.thoughtcrime.securesms.jobs.PaymentLedgerUpdateJob;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.lock.v2.CreateSvrPinActivity;
 import org.thoughtcrime.securesms.payments.FiatMoneyUtil;
+import org.thoughtcrime.securesms.payments.PaymentAmountFormatter;
 import org.thoughtcrime.securesms.payments.MoneyView;
 import org.thoughtcrime.securesms.payments.PaymentSnippetRefresher;
 import org.thoughtcrime.securesms.payments.backup.RecoveryPhraseStates;
@@ -110,7 +111,7 @@ public class PaymentsHomeFragment extends LoggingFragment {
    *  centrally by {@link MoneyView#setMoney} so no caller-side toggle check is needed. */
   private void renderBalance(@NonNull MoneyView balance) {
     if (!balanceVisible) {
-      balance.setText("••••••");
+      balance.setText(PaymentAmountFormatter.HIDDEN_AMOUNT);
     } else if (lastBalanceAmount != null) {
       balance.setMoney(lastBalanceAmount);
     }
@@ -124,7 +125,7 @@ public class PaymentsHomeFragment extends LoggingFragment {
       return;
     }
     if (!balanceVisible) {
-      exchangeView.setText("••••••");
+      exchangeView.setText(PaymentAmountFormatter.HIDDEN_AMOUNT);
       return;
     }
     if (lastExchangeText != null) {
@@ -409,6 +410,12 @@ public class PaymentsHomeFragment extends LoggingFragment {
     MenuItem menuItem = toolbar.getMenu().findItem(R.id.payments_home_fragment_menu_balance_visibility);
     if (menuItem != null && menuItem.isVisible()) {
       applyBalanceVisibilityMenuIcon(menuItem);
+    }
+
+    // The transaction rows below the balance are masked from the same preference, but nothing in
+    // their LiveData chain changed, so they will not re-emit on their own. Rebind them explicitly.
+    if (adapter != null) {
+      adapter.notifyItemRangeChanged(0, adapter.getItemCount());
     }
 
     // Mirrors iOS — chat-list payment snippets re-render with the new mask state.

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/details/PaymentDetailsFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/details/PaymentDetailsFragment.java
@@ -84,7 +84,7 @@ public final class PaymentDetailsFragment extends LoggingFragment {
       avatar.disableQuickContact();
       avatar.setImageResource(R.drawable.ic_ln_black);
       contactFromTo.setText(getContactFromToTextFromDirection(payment.getDirection()));
-      amount.setMoney(payment.getAmountPlusFeeWithDirection());
+      amount.setMoneyRespectingHiddenBalance(payment.getAmountPlusFeeWithDirection());
       note.setVisibility(View.GONE);
       status.setText(getStatusFromPayment(payment));
       sentByHeader.setVisibility(View.GONE);
@@ -96,7 +96,7 @@ public final class PaymentDetailsFragment extends LoggingFragment {
       sentToAmount.setVisibility(View.GONE);
 
       if (payment.getDirection() == Direction.SENT) {
-        sentFeeAmount.setMoney(payment.getFee());
+        sentFeeAmount.setMoneyRespectingHiddenBalance(payment.getFee());
         sentFeeHeader.setVisibility(View.VISIBLE);
         sentFeeAmount.setVisibility(View.VISIBLE);
       }
@@ -124,10 +124,10 @@ public final class PaymentDetailsFragment extends LoggingFragment {
 
                           if (state.getPayment().getState() == State.FAILED) {
                             amount.setTextColor(ContextCompat.getColor(requireContext(), R.color.signal_text_primary_disabled));
-                            amount.setMoney(state.getPayment().getAmountPlusFeeWithDirection(), false);
+                            amount.setMoneyRespectingHiddenBalance(state.getPayment().getAmountPlusFeeWithDirection(), false);
                             transactionInfo.setVisibility(View.GONE);
                           } else {
-                            amount.setMoney(state.getPayment().getAmountPlusFeeWithDirection());
+                            amount.setMoneyRespectingHiddenBalance(state.getPayment().getAmountPlusFeeWithDirection());
                             if (state.getPayment().isDefrag()) {
                               transactionInfo.setLearnMoreVisible(true);
                               transactionInfo.setText(R.string.PaymentsDetailsFragment__coin_cleanup_information);
@@ -146,13 +146,13 @@ public final class PaymentDetailsFragment extends LoggingFragment {
                           status.setText(describeStatus(state.getPayment()));
                           sentBy.setText(describeSentBy(state));
                           if (state.getPayment().getDirection().isReceived()) {
-                            sentToAmount.setMoney(Money.MobileCoin.ZERO);
-                            sentFeeAmount.setMoney(Money.MobileCoin.ZERO);
+                            sentToAmount.setMoneyRespectingHiddenBalance(Money.MobileCoin.ZERO);
+                            sentFeeAmount.setMoneyRespectingHiddenBalance(Money.MobileCoin.ZERO);
                             sentViews.setVisibility(View.GONE);
                           } else {
                             sentTo.setText(describeSentTo(state, state.getPayment()));
-                            sentToAmount.setMoney(state.getPayment().getAmount());
-                            sentFeeAmount.setMoney(state.getPayment().getFee());
+                            sentToAmount.setMoneyRespectingHiddenBalance(state.getPayment().getAmount());
+                            sentFeeAmount.setMoneyRespectingHiddenBalance(state.getPayment().getFee());
                             sentViews.setVisibility(View.VISIBLE);
                           }
                         }

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/model/PaymentItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/model/PaymentItem.java
@@ -94,7 +94,7 @@ public final class PaymentItem implements MappingModel<PaymentItem> {
 
     // Route through the single display layer so the row follows the sats/BTC preference
     // (mirrors MoneyView / iOS PaymentsFormat) instead of always rendering BTC.
-    return PaymentAmountFormatter.format(payment.getAmountPlusFeeWithDirection(),
+    return PaymentAmountFormatter.formatRespectingHiddenBalance(payment.getAmountPlusFeeWithDirection(),
                                          FormatterOptions.builder(Locale.getDefault())
                                                          .alwaysPrefixWithSign()
                                                          .build());


### PR DESCRIPTION
Toggling the eye on the Payments screen hid the balance and the chat-list snippet, but every other amount stayed in the clear: the conversation payment bubble, the transaction history rows, the payment details screen, the pinned message preview and the notification body all rendered the real value. Hiding your balance while your chat history still reads "Payment 12,500 sats" does not do the thing it says on the tin.

iOS solves this by splitting its formatter in two: PaymentsFormat.format() never masks, PaymentsFormat.formattedBalance() always does, and each call site picks. Android had only the non-masking half. This adds the other half:

- PaymentAmountFormatter.formatRespectingHiddenBalance(...) and MoneyView.setMoneyRespectingHiddenBalance(...), alongside the existing unmasked entry points rather than replacing them.
- HIDDEN_AMOUNT constant, replacing three ad-hoc bullet literals that had already drifted apart (the chat-list snippet used five bullets, the balance six). Everything now uses six, matching iOS.

Masked: payment details (amount, fee, sent-to, sent-fee), conversation payment bubbles including tombstones, transaction history rows, message display body (notifications and quoted replies), pinned message preview, and the balance readouts on the confirm sheet and the create-payment screen.

Deliberately NOT masked, because hiding your balance is about shoulder-surfing, not about being unable to see what you are doing:
- the amount being typed in the send flow,
- the amount/fee/total line items on the confirm sheet — you are about to authorise that number,
- the delete-account warning that you still hold funds, which exists precisely to make you look at the number.

One behavioural detail worth calling out: the eye toggle persists to SignalStore and refreshes chat-list snippets, but the history rows below it are driven by LiveData that does not re-emit when the preference flips. Without a nudge they would keep their old text until the next rebind, so the toggle now notifies the adapter as well.

Verified: :Signal-Android:compilePlayProdDebugKotlin and …JavaWithJavac. Re-grepped every remaining unmasked call site to confirm each is either already inside a hidden-balance guard (chat-list snippet, unread banner, home balance) or one of the deliberate exclusions above.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
