### PR TITLE
Cap deposit claim fee at network-recommended, not a flat 5 sat/vB

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/BreezSdkWrapper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/BreezSdkWrapper.kt
@@ -287,7 +287,11 @@ class BreezSdkWrapper(ledger: BreezSdk?) {
 
         config.lnurlDomain = LNURL_DOMAIN
         config.preferSparkOverLightning = true
-        config.maxDepositClaimFee = MaxFee.Rate(satPerVbyte = 5u)
+        // Cap auto-claiming of on-chain deposits at the network's own recommended fee plus 5
+        // sat/vB of headroom, rather than a flat 5 sat/vB ceiling. A fixed cap silently stops
+        // claiming deposits whenever the mempool sits above it, which is exactly when a user is
+        // most likely to be watching for the funds. Matches iOS (79f87e5654).
+        config.maxDepositClaimFee = MaxFee.NetworkRecommended(leewaySatPerVbyte = 5u)
 
         val dataDir = AppDependencies.application.applicationInfo.dataDir
 


### PR DESCRIPTION
Android set maxDepositClaimFee to MaxFee.Rate(5), a fixed ceiling; iOS sets MaxFee.networkRecommended(leewaySatPerVbyte: 5) (79f87e5654). The two clients have been auto-claiming on-chain deposits under different policies since both landed on the same day.

A flat cap stops claiming whenever the mempool sits above 5 sat/vB — which is precisely when a user is most likely to be waiting on the funds and least likely to understand why nothing arrived. Tracking the network's own recommendation with 5 sat/vB of headroom keeps claiming through fee spikes and still refuses to overpay.

Confirmed MaxFee.NetworkRecommended(leewaySatPerVbyte: ULong) exists in the breez_sdk_spark 0.18.0 Kotlin bindings, matching the Swift case exactly.

Blast radius is one line in BreezSdkWrapper.connect: the value is read only when building the SDK Config, affects only on-chain deposit auto-claim, and is picked up on the next connect (the SDK instance is a cached singleton).

Verified: :Signal-Android:compilePlayProdDebugKotlin.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
