### PR TITLE
Hide the paid Backups tier behind a PAID_BACKUPS_ENABLED build flag (…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -273,6 +273,10 @@ android {
     buildConfigField("String", "STRIPE_PUBLISHABLE_KEY", "\"pk_live_6cmGZopuTsV8novGgJJW9JpC00vLIgtQ1D\"")
     buildConfigField("boolean", "TRACING_ENABLED", "false")
     buildConfigField("boolean", "LINK_DEVICE_UX_ENABLED", "true")
+    // Radar does not sell the paid Backups tier. Mirrors iOS
+    // BuildFlags.Backups.showPaidPlan = false: hides the paid tier in the plan chooser and the
+    // free-tier upgrade button, while leaving manage/cancel reachable for existing subscribers.
+    buildConfigField("boolean", "PAID_BACKUPS_ENABLED", "false")
     buildConfigField("boolean", "USE_STRING_ID", "true")
 
     ndk {

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/ui/subscription/MessageBackupsFlowViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/ui/subscription/MessageBackupsFlowViewModel.kt
@@ -25,6 +25,7 @@ import org.signal.core.util.billing.BillingPurchaseResult
 import org.signal.core.util.concurrent.SignalDispatchers
 import org.signal.core.util.logging.Log
 import org.signal.donations.InAppPaymentType
+import org.thoughtcrime.securesms.BuildConfig
 import org.thoughtcrime.securesms.backup.DeletionState
 import org.thoughtcrime.securesms.backup.v2.BackupRepository
 import org.thoughtcrime.securesms.backup.v2.MessageBackupTier
@@ -102,9 +103,14 @@ class MessageBackupsFlowViewModel(
     viewModelScope.launch {
       val allBackupTypes: List<MessageBackupsType> = try {
         withContext(SignalDispatchers.IO) {
-          BackupRepository.getBackupTypes(
+          // Radar does not offer the paid tier, so it is never requested and therefore never
+          // appears in the chooser. Mirrors iOS BuildFlags.Backups.showPaidPlan = false.
+          val offeredTiers = if (BuildConfig.PAID_BACKUPS_ENABLED) {
             listOf(MessageBackupTier.FREE, MessageBackupTier.PAID)
-          )
+          } else {
+            listOf(MessageBackupTier.FREE)
+          }
+          BackupRepository.getBackupTypes(offeredTiers)
         }
       } catch (e: Exception) {
         Log.w(TAG, "Failed to download available backup types.", e)

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/backups/remote/RemoteBackupsSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/backups/remote/RemoteBackupsSettingsFragment.kt
@@ -87,6 +87,7 @@ import org.signal.core.util.gibiBytes
 import org.signal.core.util.logging.Log
 import org.signal.core.util.mebiBytes
 import org.signal.core.util.money.FiatMoney
+import org.thoughtcrime.securesms.BuildConfig
 import org.thoughtcrime.securesms.BiometricDeviceAuthentication
 import org.thoughtcrime.securesms.BiometricDeviceLockContract
 import org.thoughtcrime.securesms.DevicePinAuthEducationSheet
@@ -1100,7 +1101,15 @@ private fun BackupCard(
       )
     }
 
-    if (backupState.isActive() && isPaidTierPricingAvailable && isGooglePlayServicesAvailable) {
+    // The Free-tier button is the "upgrade to paid" call to action, so it is gated off with the
+    // paid tier. The Paid-tier button is "manage or cancel" and must stay reachable for anyone who
+    // already holds a subscription. iOS gates exactly the same half.
+    val canShowBackupTypeAction = backupState.isActive() &&
+      isPaidTierPricingAvailable &&
+      isGooglePlayServicesAvailable &&
+      (BuildConfig.PAID_BACKUPS_ENABLED || messageBackupsType is MessageBackupsType.Paid)
+
+    if (canShowBackupTypeAction) {
       val buttonText = when (messageBackupsType) {
         is MessageBackupsType.Paid -> stringResource(R.string.RemoteBackupsSettingsFragment__manage_or_cancel)
         is MessageBackupsType.Free -> stringResource(R.string.RemoteBackupsSettingsFragment__upgrade)


### PR DESCRIPTION
…off)

Radar does not sell the paid Backups plan, but Android still offered it: the plan chooser listed the paid tier with the full Google Play billing path, and Backup settings showed an "Upgrade" call to action. iOS gates both with BuildFlags.Backups.showPaidPlan = false (2197d1d538).

Two surfaces, gated the same way iOS gates them:

- Plan chooser — MessageBackupsFlowViewModel now asks BackupRepository for FREE only, so the paid tier never enters allBackupTypes and cannot be selected. The existing "if the selected tier is not in the list, fall back to the first" logic already handles the narrowed list, and the one place that reaches for the paid type is guarded by a contains() check, so a single-element list is safe.
- Backup settings — the type action button is split by tier: the Free-tier button *is* the upgrade CTA and goes with the flag, while the Paid-tier "Manage or cancel" button stays. That distinction is deliberate and matches iOS, which gates only its freeAndEnabled upgrade button: anyone who already holds a subscription must still be able to manage or cancel it. For the same reason onRenewLostSubscription is left alone — it only fires for a subscriber whose purchase went missing.

Verified: :Signal-Android:compilePlayProdDebugKotlin.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
