### PR TITLE
Point linked-device install link at Radar, add Radar copyright

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/help/HelpSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/help/HelpSettingsFragment.kt
@@ -116,6 +116,10 @@ class HelpSettingsFragment : ComposeFragment() {
               label = StringBuilder().apply {
                 append(getString(R.string.HelpFragment__copyright_signal_messenger))
                 append("\n")
+                // Radar's own copyright alongside the upstream notice. Deliberately keeps the
+                // AGPL line that iOS dropped: the licence requires the notice be preserved.
+                append(getString(R.string.HelpFragment__copyright_radar))
+                append("\n")
                 append(getString(R.string.HelpFragment__licenced_under_the_agplv3))
               }.toString()
             )

--- a/app/src/main/java/org/thoughtcrime/securesms/linkdevice/LinkDeviceLearnMoreBottomSheetFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/linkdevice/LinkDeviceLearnMoreBottomSheetFragment.kt
@@ -34,10 +34,6 @@ class LinkDeviceLearnMoreBottomSheetFragment : ComposeBottomSheetDialogFragment(
 
   override val peekHeightPercentage: Float = 0.8f
 
-  companion object {
-    const val SIGNAL_DOWNLOAD_URL = "https://signal.org/download"
-  }
-
   @Composable
   override fun SheetContent() {
     LearnMoreSheet()
@@ -47,9 +43,13 @@ class LinkDeviceLearnMoreBottomSheetFragment : ComposeBottomSheetDialogFragment(
 @Composable
 fun LearnMoreSheet() {
   val context = LocalContext.current
+  // Display text and link target both point at Radar's own install page: the sentence says
+  // "install Radar", so sending people to signal.org/download would install the wrong app.
+  // The href reuses install_url so there is a single source of truth for that address.
   val downloadUrl = stringResource(id = R.string.LinkDeviceFragment__signal_download_url)
+  val downloadHref = stringResource(id = R.string.install_url)
   val fullString = stringResource(id = R.string.LinkDeviceFragment__on_other_device_visit_signal, downloadUrl)
-  val spanned = SpanUtil.urlSubsequence(fullString, downloadUrl, LinkDeviceLearnMoreBottomSheetFragment.SIGNAL_DOWNLOAD_URL)
+  val spanned = SpanUtil.urlSubsequence(fullString, downloadUrl, downloadHref)
 
   return Column(
     horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1049,7 +1049,7 @@
     <string name="LinkDeviceFragment__signal_messages_are_synchronized">Radar messages are synchronized with Radar on your mobile phone after it is linked. Your previous message history will not appear.</string>
     <!-- Bottom sheet description explaining that for non-desktop/iPad devices, they should go to %s to download Signal where %s is Signal\'s website -->
     <string name="LinkDeviceFragment__on_other_device_visit_signal">On the device you want to link, visit %s to install Radar</string>
-    <string name="LinkDeviceFragment__signal_download_url" translatable="false">signal.org/download</string>
+    <string name="LinkDeviceFragment__signal_download_url" translatable="false">radar.chat/install</string>
     <!-- Header title listing out current linked devices -->
     <string name="LinkDeviceFragment__my_linked_devices">My linked devices</string>
     <!-- Dialog confirmation to unlink a device -->
@@ -5912,6 +5912,7 @@
     <string name="HelpSettingsFragment__terms_amp_privacy_policy">Terms &amp; Privacy Policy</string>
     <string name="HelpFragment__copyright_signal_messenger">Copyright Signal Messenger</string>
     <string name="HelpFragment__licenced_under_the_agplv3">Licensed under the GNU AGPLv3</string>
+    <string name="HelpFragment__copyright_radar" translatable="false">Copyright 2026 Radar Chat, Inc.</string>
 
     <!-- DataAndStorageSettingsFragment -->
     <string name="DataAndStorageSettingsFragment__media_quality">Media quality</string>


### PR DESCRIPTION
Two leftovers from the rebrand, both in surfaces iOS already fixed (ae310c1edc).

The "Learn more" sheet for linking a device read: "On the device you want to link, visit signal.org/download to install Radar" — and the tappable link actually navigated to https://signal.org/download, from a hardcoded constant that sat beside the display string. Following it installs Signal, not Radar. Both halves now point at Radar's own install page, and the href reuses the existing install_url resource so there is one source of truth for that address instead of a second hardcoded copy.

The Help screen showed only "Copyright Signal Messenger". Added Radar's own copyright line beneath it. Deliberately keeps the "Licensed under the GNU AGPLv3" line that iOS dropped in the same change — the licence requires that notice be preserved, and dropping it is not something to mirror.

The new copyright string is translatable="false": it is proper nouns and a year, so it renders identically in every locale and needs no translation pass. The Signal copyright string is untouched, so the existing translations in all 68 locale files stay valid. The download URL is already excluded from the locale files as non-translatable, so no locale churn either.

Verified: :Signal-Android:compilePlayProdDebugKotlin. Traced the sheet flow end to end — display text "radar.chat/install" is linkified against https://radar.chat/install/ and handed to openBrowserLink; the removed constant had no other references.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
