### PR TITLE
Declare the usernameChangeSyncMessage account capability

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/AppCapabilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/AppCapabilities.kt
@@ -13,7 +13,8 @@ object AppCapabilities {
       storage = storageCapable,
       versionedExpirationTimer = true,
       attachmentBackfill = true,
-      spqr = true
+      spqr = true,
+      usernameChangeSyncMessage = true
     )
   }
 }

--- a/libsignal-service/src/main/java/org/whispersystems/signalservice/api/account/AccountAttributes.kt
+++ b/libsignal-service/src/main/java/org/whispersystems/signalservice/api/account/AccountAttributes.kt
@@ -57,6 +57,7 @@ class AccountAttributes @JsonCreator constructor(
     @JsonProperty val storage: Boolean,
     @JsonProperty val versionedExpirationTimer: Boolean,
     @JsonProperty val attachmentBackfill: Boolean,
-    @JsonProperty val spqr: Boolean
+    @JsonProperty val spqr: Boolean,
+    @JsonProperty val usernameChangeSyncMessage: Boolean
   )
 }

--- a/registration/app/src/main/java/org/signal/registration/sample/dependencies/RealNetworkController.kt
+++ b/registration/app/src/main/java/org/signal/registration/sample/dependencies/RealNetworkController.kt
@@ -615,7 +615,8 @@ class RealNetworkController(
       storage,
       versionedExpirationTimer,
       attachmentBackfill,
-      spqr
+      spqr,
+      usernameChangeSyncMessage
     )
   }
 

--- a/registration/lib/src/main/java/org/signal/registration/NetworkController.kt
+++ b/registration/lib/src/main/java/org/signal/registration/NetworkController.kt
@@ -283,7 +283,8 @@ interface NetworkController {
       val storage: Boolean,
       val versionedExpirationTimer: Boolean,
       val attachmentBackfill: Boolean,
-      val spqr: Boolean
+      val spqr: Boolean,
+      val usernameChangeSyncMessage: Boolean
     )
   }
 

--- a/registration/lib/src/main/java/org/signal/registration/RegistrationRepository.kt
+++ b/registration/lib/src/main/java/org/signal/registration/RegistrationRepository.kt
@@ -134,7 +134,8 @@ class RegistrationRepository(val networkController: NetworkController, val stora
         storage = false,
         versionedExpirationTimer = true,
         attachmentBackfill = true,
-        spqr = true
+        spqr = true,
+        usernameChangeSyncMessage = true
       ),
       name = null,
       pniRegistrationId = keyMaterial.pniRegistrationId,


### PR DESCRIPTION
Radar iOS added this alongside attachmentBackfill in "Update AccountAttributes for fix linking secondary devices" (8b8a4c5cb7). Android declared attachmentBackfill but not this one, so the two clients advertised different capability sets to the same server while Radar ships with the link-device flow enabled (LINK_DEVICE_UX_ENABLED = true).

Note this is a server-facing advertisement, not an implementation contract: neither Radar iOS nor Android defines a username-change sync message in its proto or handles one in its sync processor. The server reads the flag to decide linked-device behaviour. This brings Android to exactly the state iOS is in.

The parameter is added without a default so the compiler forces every construction site to be explicit rather than silently omitting it. That covers three modules: the app's AppCapabilities, and the standalone registration library plus its sample app, which carry their own copy of the wire type.

Verified: :Signal-Android:compilePlayProdDebugKotlin, :registration and :registration-app all compile. Jackson serializes the property under its Kotlin name, matching the "usernameChangeSyncMessage" key iOS sends.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
